### PR TITLE
[codex] Add thinclient management center

### DIFF
--- a/beagle-host/bin/beagle-guest-updater
+++ b/beagle-host/bin/beagle-guest-updater
@@ -659,6 +659,8 @@ def main() -> int:
     subparsers.add_parser("rollback")
     subparsers.add_parser("check-in")
     subparsers.add_parser("poll-actions")
+    subparsers.add_parser("reboot")
+    subparsers.add_parser("shutdown")
     subparsers.add_parser("status")
     args = parser.parse_args()
 
@@ -688,6 +690,16 @@ def main() -> int:
             print_json(check_in(config))
         elif args.command == "poll-actions":
             print_json(poll_actions(config))
+        elif args.command == "reboot":
+            status = status_payload(config, state="reboot-scheduled", pending_reboot=True, reboot_target="vm")
+            check_in(config)
+            schedule_reboot()
+            print_json(status)
+        elif args.command == "shutdown":
+            status = status_payload(config, state="shutdown-scheduled", reboot_target="vm")
+            check_in(config)
+            schedule_shutdown()
+            print_json(status)
         elif args.command == "status":
             print_json(status_payload(config))
         return 0

--- a/beagle-host/netbridge/beagle-netbridge-agent
+++ b/beagle-host/netbridge/beagle-netbridge-agent
@@ -64,6 +64,14 @@ USBCTL = os.environ.get(
     "BEAGLE_NETBRIDGE_USBCTL",
     "/usr/local/lib/pve-thin-client/runtime/beagle-usbctl.sh",
 )
+THINCLIENT_UPDATE_CLIENT = os.environ.get(
+    "BEAGLE_NETBRIDGE_UPDATE_CLIENT",
+    "/usr/local/sbin/beagle-update-client",
+)
+THINCLIENT_UPDATE_STATUS_FILE = os.environ.get(
+    "BEAGLE_NETBRIDGE_UPDATE_STATUS_FILE",
+    "/var/lib/beagle-os/update/status.json",
+)
 
 STREAM_PROFILE_KEYS = {
     "resolution": "PVE_THIN_CLIENT_BEAGLE_STREAM_CLIENT_RESOLUTION",
@@ -205,6 +213,15 @@ def _json_cmd(args: list[str], timeout: int = 10) -> dict | None:
     except ValueError:
         return {"ok": False, "error": "invalid json response"}
     return payload if isinstance(payload, dict) else {"ok": False, "error": "invalid json response"}
+
+
+def _read_json_file(path: str) -> dict:
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, ValueError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
 
 
 def _list_network_interfaces() -> list[dict]:
@@ -374,10 +391,24 @@ def _thinclient_status() -> dict:
         "services": services,
         "network": {"interfaces": _list_network_interfaces()},
         "usb": usb,
+        "update": _thinclient_update_status(),
         "audio": {"capture_devices": _list_audio_capture_devices()},
         "video": {"devices": _list_video_devices()},
         "stream": _stream_profile_status(),
     }
+
+
+def _thinclient_update_status() -> dict:
+    status = _read_json_file(THINCLIENT_UPDATE_STATUS_FILE)
+    if not status and os.access(THINCLIENT_UPDATE_CLIENT, os.X_OK):
+        payload = _json_cmd([THINCLIENT_UPDATE_CLIENT, "status"], timeout=15)
+        if isinstance(payload, dict):
+            status = payload
+    status.setdefault("client", "thinclient-update-client")
+    status.setdefault("state", "unknown" if os.access(THINCLIENT_UPDATE_CLIENT, os.X_OK) else "missing")
+    status.setdefault("pending_reboot", False)
+    status.setdefault("reboot_target", "thinclient" if status.get("pending_reboot") else "")
+    return status
 
 
 # --------------------------------------------------------------------------- #
@@ -914,6 +945,57 @@ class Agent:
             return payload
         return {"ok": True, "action": action}
 
+    def thinclient_update_action(self, req: dict) -> dict:
+        action = str(req.get("action", "status")).strip()
+        if not os.access(THINCLIENT_UPDATE_CLIENT, os.X_OK):
+            return {"ok": False, "error": "thinclient update client not installed", "update": _thinclient_update_status()}
+        if action == "status":
+            return {"ok": True, "action": action, "update": _thinclient_update_status()}
+        commands = {
+            "scan": [THINCLIENT_UPDATE_CLIENT, "scan", "--force"],
+            "apply": [THINCLIENT_UPDATE_CLIENT, "apply", "--reboot"],
+            "rollback": [THINCLIENT_UPDATE_CLIENT, "rollback", "--reboot"],
+        }
+        command = commands.get(action)
+        if command is None:
+            return {"ok": False, "error": "unsupported thinclient update action"}
+        try:
+            result = _run(command, timeout=1800)
+        except (OSError, subprocess.SubprocessError) as exc:
+            return {"ok": False, "error": str(exc), "update": _thinclient_update_status()}
+        payload: dict = {}
+        if result.stdout.strip():
+            try:
+                parsed = json.loads(result.stdout)
+                payload = parsed if isinstance(parsed, dict) else {}
+            except ValueError:
+                payload = {}
+        if result.returncode != 0:
+            return {
+                "ok": False,
+                "error": result.stderr.strip() or result.stdout.strip() or f"update client exit {result.returncode}",
+                "update": _thinclient_update_status(),
+            }
+        return {"ok": True, "action": action, "update": payload or _thinclient_update_status()}
+
+    def power_action(self, req: dict) -> dict:
+        action = str(req.get("action", "")).strip()
+        commands = {
+            "reboot": ["systemctl", "reboot", "--no-block"],
+            "poweroff": ["systemctl", "poweroff", "--no-block"],
+        }
+        command = commands.get(action)
+        if command is None:
+            return {"ok": False, "error": "unsupported power action"}
+        try:
+            result = _run(command, timeout=8)
+        except (OSError, subprocess.SubprocessError) as exc:
+            return {"ok": False, "error": str(exc)}
+        if result.returncode != 0:
+            return {"ok": False, "error": result.stderr.strip() or result.stdout.strip()}
+        log(f"thinclient power action requested: {action}")
+        return {"ok": True, "target": "thinclient", "action": action}
+
     def _allocate_port(self) -> int:
         for port in PROXY_PORT_RANGE:
             if port not in self.used_ports:
@@ -1030,6 +1112,12 @@ class Agent:
             return self._catalog_payload(result)
         if op == "usb_unbind":
             result = self.usb_action(request, "unbind")
+            return self._catalog_payload(result)
+        if op == "thinclient_update":
+            result = self.thinclient_update_action(request)
+            return self._catalog_payload(result)
+        if op == "thinclient_power":
+            result = self.power_action(request)
             return self._catalog_payload(result)
         if op == "restart":
             return self.restart_agent()

--- a/beagle-host/netbridge/beagle-netbridge-agent.service
+++ b/beagle-host/netbridge/beagle-netbridge-agent.service
@@ -15,8 +15,9 @@ ProtectHome=yes
 PrivateTmp=yes
 # Persist manual devices added through the in-VM manager under /var/lib/beagle/netbridge.
 StateDirectory=beagle/netbridge
-# Stream quality presets are written into the launcher override state.
-ReadWritePaths=/var/lib/beagle-os
+# Stream presets and update actions write into Beagle state/cache and, on live
+# media, the persisted USB slot layout.
+ReadWritePaths=/var/lib/beagle-os /var/cache/beagle-os /var/log/beagle-os /run/live/medium /lib/live/mount/medium
 
 [Install]
 WantedBy=multi-user.target

--- a/beagle-host/netbridge/beagle-netbridge-tray
+++ b/beagle-host/netbridge/beagle-netbridge-tray
@@ -40,6 +40,10 @@ MANAGED_PREFIX = "beagle-net-"
 CONTROL_TIMEOUT = 6
 APP_ID = "com.beagle-os.netbridge.tray"
 APP_NAME = "Beagle NetBridge"
+ADMIN_APP_PATHS = (
+    str(Path(__file__).resolve().with_name("beagle-thinclient-admin")),
+    "/usr/local/bin/beagle-thinclient-admin",
+)
 GUEST_UPDATER = "/usr/local/sbin/beagle-guest-updater"
 GUEST_UPDATE_STATUS_FILE = Path("/var/lib/beagle/guest-updater/status.json")
 DESKTOP_PROFILE_STATUS_FILE = Path("/var/lib/beagle/guest-updater/desktop-profile.json")
@@ -151,6 +155,12 @@ class NetBridgeControl:
 
     def service_action(self, service: str, action: str = "restart") -> dict | None:
         return self.request("service_action", service=service, action=action)
+
+    def thinclient_update(self, action: str = "status") -> dict | None:
+        return self.request("thinclient_update", action=action)
+
+    def thinclient_power(self, action: str) -> dict | None:
+        return self.request("thinclient_power", action=action)
 
     def usb_bind(self, busid: str) -> dict | None:
         return self.request("usb_bind", busid=busid)
@@ -519,6 +529,7 @@ def run_tray() -> int:
                     self._add_device_menu(device)
 
             self.menu.addSeparator()
+            self.menu.addAction("Thinclient Verwaltung öffnen", self.action_open_admin)
             self.menu.addAction("Geräte suchen…", self.action_rescan)
             self.menu.addAction("Gerät hinzufügen…", self.action_add)
             self.menu.addAction("Druckerverwaltung öffnen", self.action_open_cups)
@@ -752,6 +763,16 @@ def run_tray() -> int:
 
         def action_open_cups(self) -> None:
             QtGui.QDesktopServices.openUrl(QtCore.QUrl("http://localhost:631/printers/"))
+
+        def action_open_admin(self) -> None:
+            for candidate in ADMIN_APP_PATHS:
+                if os.access(candidate, os.X_OK):
+                    try:
+                        subprocess.Popen([candidate], close_fds=True)
+                    except OSError as exc:
+                        self._notify(APP_NAME, f"Thinclient Verwaltung konnte nicht gestartet werden: {exc}")
+                    return
+            self._notify(APP_NAME, "Thinclient Verwaltung ist nicht installiert.")
 
         def action_set_stream_profile(self, profile: str) -> None:
             def op():

--- a/beagle-host/netbridge/beagle-thinclient-admin
+++ b/beagle-host/netbridge/beagle-thinclient-admin
@@ -1,0 +1,893 @@
+#!/usr/bin/env python3
+"""Beagle thin-client administration app (in-VM side).
+
+This is the full desktop control center for the thin client behind a streamed
+VM. The system tray stays a quick launcher; this app owns the larger workflows:
+updates, endpoint status, USB/audio/video, services, stream profiles and shared
+LAN devices.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from types import ModuleType
+
+APP_ID = "com.beagle-os.thinclient.admin"
+APP_NAME = "Beagle Thinclient Verwaltung"
+TRAY_SCRIPT_CANDIDATES = (
+    Path(__file__).resolve().with_name("beagle-netbridge-tray"),
+    Path("/usr/local/bin/beagle-netbridge-tray"),
+)
+
+
+def load_netbridge_module() -> ModuleType:
+    for path in TRAY_SCRIPT_CANDIDATES:
+        if path.is_file():
+            return SourceFileLoader("beagle_netbridge_tray_admin_backend", str(path)).load_module()
+    raise FileNotFoundError("beagle-netbridge-tray backend not found")
+
+
+backend = load_netbridge_module()
+
+
+def compact(value: object, default: str = "-") -> str:
+    text = str(value if value not in (None, "") else default)
+    return text[:180]
+
+
+def service_label(key: str) -> str:
+    labels = {
+        "usb_tunnel": "USB/Mic Tunnel",
+        "camera_stream": "Webcam Stream",
+        "audio_input_bridge": "Mic Bridge Quelle",
+        "stream": "Stream Launcher",
+        "kiosk": "Kiosk Session",
+        "netbridge_agent": "NetBridge Agent",
+    }
+    return labels.get(key, key.replace("_", " ").title())
+
+
+def reboot_target_label(status: dict, fallback: str) -> str:
+    if not isinstance(status, dict):
+        return fallback
+    target = str(status.get("reboot_target", "") or "").strip().lower()
+    if target == "thinclient":
+        return "Thinclient"
+    if target in {"vm", "desktop", "guest"}:
+        return "Diese VM"
+    if status.get("pending_reboot"):
+        return fallback
+    return "-"
+
+
+def update_state_label(status: dict) -> str:
+    state = str(status.get("state", "unknown") if isinstance(status, dict) else "unknown")
+    if status.get("pending_reboot") if isinstance(status, dict) else False:
+        return f"{state} | Neustart: {reboot_target_label(status, '-')}"
+    return state
+
+
+class AddDeviceDialog:
+    def __init__(self, parent=None) -> None:
+        from PyQt5 import QtWidgets
+
+        self.dialog = QtWidgets.QDialog(parent)
+        self.dialog.setWindowTitle("Netzwerkgeraet hinzufuegen")
+        self.dialog.setModal(True)
+        form = QtWidgets.QFormLayout(self.dialog)
+
+        self.name_edit = QtWidgets.QLineEdit()
+        self.name_edit.setPlaceholderText("Buerodrucker")
+        self.address_edit = QtWidgets.QLineEdit()
+        self.address_edit.setPlaceholderText("192.168.178.50 oder printer.local")
+        self.kind_combo = QtWidgets.QComboBox()
+        self.kind_combo.addItem("Raw / JetDirect", "raw")
+        self.kind_combo.addItem("IPP", "ipp")
+        self.port_spin = QtWidgets.QSpinBox()
+        self.port_spin.setRange(1, 65535)
+        self.port_spin.setValue(9100)
+        self.rp_edit = QtWidgets.QLineEdit("ipp/print")
+
+        form.addRow("Name", self.name_edit)
+        form.addRow("Adresse", self.address_edit)
+        form.addRow("Typ", self.kind_combo)
+        form.addRow("Port", self.port_spin)
+        form.addRow("IPP-Pfad", self.rp_edit)
+
+        self.kind_combo.currentIndexChanged.connect(self._sync_kind)
+        self._sync_kind()
+
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel
+        )
+        buttons.accepted.connect(self.dialog.accept)
+        buttons.rejected.connect(self.dialog.reject)
+        form.addRow(buttons)
+
+    def _sync_kind(self) -> None:
+        if self.kind_combo.currentData() == "raw":
+            self.port_spin.setValue(9100)
+            self.rp_edit.setEnabled(False)
+            return
+        if self.port_spin.value() == 9100:
+            self.port_spin.setValue(631)
+        self.rp_edit.setEnabled(True)
+
+    def exec_(self) -> int:
+        return self.dialog.exec_()
+
+    def values(self) -> dict:
+        return {
+            "name": self.name_edit.text().strip(),
+            "address": self.address_edit.text().strip(),
+            "port": self.port_spin.value(),
+            "rp": self.rp_edit.text().strip() or "ipp/print",
+        }
+
+
+def run_app() -> int:
+    from PyQt5 import QtCore, QtGui, QtWidgets
+
+    class AdminWindow(QtWidgets.QMainWindow):
+        dataReady = QtCore.pyqtSignal(object, object, object)
+        actionDone = QtCore.pyqtSignal(str, str, bool)
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.control = backend.NetBridgeControl()
+            self.catalog: dict | None = None
+            self.wired: dict[str, str] = {}
+            self.update_status: dict = backend.guest_update_snapshot()
+            self._busy = False
+
+            self.setWindowTitle(APP_NAME)
+            self.setMinimumSize(980, 680)
+            self.setWindowIcon(self._icon())
+            self._build_ui()
+
+            self.dataReady.connect(self._render)
+            self.actionDone.connect(self._show_action_result)
+
+            self.timer = QtCore.QTimer(self)
+            self.timer.setInterval(20000)
+            self.timer.timeout.connect(self.refresh)
+            self.timer.start()
+            self.refresh()
+
+        def _icon(self):
+            for path in backend.ICON_PATHS:
+                if os.path.exists(path):
+                    icon = QtGui.QIcon(path)
+                    if not icon.isNull():
+                        return icon
+            icon = QtGui.QIcon.fromTheme("preferences-system")
+            if icon.isNull():
+                pixmap = QtGui.QPixmap(64, 64)
+                pixmap.fill(QtGui.QColor("#2457a6"))
+                icon = QtGui.QIcon(pixmap)
+            return icon
+
+        def _build_ui(self) -> None:
+            root = QtWidgets.QWidget()
+            layout = QtWidgets.QVBoxLayout(root)
+            layout.setContentsMargins(14, 14, 14, 14)
+            layout.setSpacing(10)
+
+            header = QtWidgets.QHBoxLayout()
+            title = QtWidgets.QLabel(APP_NAME)
+            title.setObjectName("appTitle")
+            self.status_label = QtWidgets.QLabel("Status wird geladen")
+            self.status_label.setAlignment(QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter)
+            self.refresh_button = QtWidgets.QPushButton("Aktualisieren")
+            self.refresh_button.clicked.connect(self.refresh)
+            header.addWidget(title, 1)
+            header.addWidget(self.status_label, 2)
+            header.addWidget(self.refresh_button)
+            layout.addLayout(header)
+
+            self.tabs = QtWidgets.QTabWidget()
+            layout.addWidget(self.tabs, 1)
+            self.setCentralWidget(root)
+
+            self.overview = QtWidgets.QWidget()
+            self.updates = QtWidgets.QWidget()
+            self.stream = QtWidgets.QWidget()
+            self.services = QtWidgets.QWidget()
+            self.usb = QtWidgets.QWidget()
+            self.devices = QtWidgets.QWidget()
+            self.network = QtWidgets.QWidget()
+            self.diagnostics = QtWidgets.QWidget()
+            for widget, label in (
+                (self.overview, "Uebersicht"),
+                (self.updates, "Updates & Neustart"),
+                (self.stream, "Stream"),
+                (self.services, "Dienste"),
+                (self.usb, "USB, Audio, Webcam"),
+                (self.devices, "LAN-Geraete"),
+                (self.network, "Netzwerk"),
+                (self.diagnostics, "Diagnose"),
+            ):
+                self.tabs.addTab(widget, label)
+
+            self._build_overview()
+            self._build_updates()
+            self._build_stream()
+            self._build_services()
+            self._build_usb()
+            self._build_devices()
+            self._build_network()
+            self._build_diagnostics()
+            self._apply_style()
+
+        def _build_overview(self) -> None:
+            layout = QtWidgets.QVBoxLayout(self.overview)
+            self.overview_grid = QtWidgets.QTableWidget(0, 2)
+            self.overview_grid.setHorizontalHeaderLabels(["Bereich", "Status"])
+            self.overview_grid.horizontalHeader().setStretchLastSection(True)
+            self.overview_grid.verticalHeader().setVisible(False)
+            self.overview_grid.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
+            layout.addWidget(self.overview_grid)
+
+            actions = QtWidgets.QHBoxLayout()
+            for text, slot in (
+                ("Updates suchen", self.scan_updates),
+                ("Updates installieren", self.apply_updates),
+                ("VM neu starten", lambda: self.vm_power_action("reboot")),
+                ("Thinclient neu starten", lambda: self.thinclient_power_action("reboot")),
+                ("Stream neu starten", lambda: self.service_action("stream", "restart")),
+                ("Agent neu starten", self.restart_agent),
+            ):
+                button = QtWidgets.QPushButton(text)
+                button.clicked.connect(slot)
+                actions.addWidget(button)
+            actions.addStretch(1)
+            layout.addLayout(actions)
+
+        def _build_updates(self) -> None:
+            layout = QtWidgets.QVBoxLayout(self.updates)
+            split = QtWidgets.QHBoxLayout()
+
+            vm_box = QtWidgets.QGroupBox("Diese VM")
+            vm_layout = QtWidgets.QVBoxLayout(vm_box)
+            self.update_grid = QtWidgets.QTableWidget(0, 2)
+            self.update_grid.setHorizontalHeaderLabels(["Feld", "Wert"])
+            self.update_grid.horizontalHeader().setStretchLastSection(True)
+            self.update_grid.verticalHeader().setVisible(False)
+            self.update_grid.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
+            vm_layout.addWidget(self.update_grid)
+            vm_actions = QtWidgets.QHBoxLayout()
+            for text, slot in (
+                ("Nach Updates suchen", self.scan_updates),
+                ("Updates installieren + Neustart", self.apply_updates),
+                ("Desktop-Profil erneuern", self.refresh_desktop_profile),
+                ("VM neu starten", lambda: self.vm_power_action("reboot")),
+                ("VM herunterfahren", lambda: self.vm_power_action("shutdown")),
+            ):
+                button = QtWidgets.QPushButton(text)
+                button.clicked.connect(slot)
+                vm_actions.addWidget(button)
+            vm_actions.addStretch(1)
+            vm_layout.addLayout(vm_actions)
+
+            tc_box = QtWidgets.QGroupBox("Thinclient")
+            tc_layout = QtWidgets.QVBoxLayout(tc_box)
+            self.thin_update_grid = QtWidgets.QTableWidget(0, 2)
+            self.thin_update_grid.setHorizontalHeaderLabels(["Feld", "Wert"])
+            self.thin_update_grid.horizontalHeader().setStretchLastSection(True)
+            self.thin_update_grid.verticalHeader().setVisible(False)
+            self.thin_update_grid.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
+            tc_layout.addWidget(self.thin_update_grid)
+            tc_actions = QtWidgets.QHBoxLayout()
+            for text, slot in (
+                ("Thinclient-Update suchen", lambda: self.thinclient_update_action("scan")),
+                ("Thinclient-Update installieren + Neustart", lambda: self.thinclient_update_action("apply")),
+                ("Rollback + Neustart", lambda: self.thinclient_update_action("rollback")),
+                ("Thinclient neu starten", lambda: self.thinclient_power_action("reboot")),
+                ("Thinclient herunterfahren", lambda: self.thinclient_power_action("poweroff")),
+            ):
+                button = QtWidgets.QPushButton(text)
+                button.clicked.connect(slot)
+                tc_actions.addWidget(button)
+            tc_actions.addStretch(1)
+            tc_layout.addLayout(tc_actions)
+
+            split.addWidget(vm_box, 1)
+            split.addWidget(tc_box, 1)
+            layout.addLayout(split, 1)
+
+        def _build_stream(self) -> None:
+            layout = QtWidgets.QVBoxLayout(self.stream)
+            self.stream_table = QtWidgets.QTableWidget(0, 2)
+            self.stream_table.setHorizontalHeaderLabels(["Feld", "Wert"])
+            self.stream_table.horizontalHeader().setStretchLastSection(True)
+            self.stream_table.verticalHeader().setVisible(False)
+            self.stream_table.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
+            layout.addWidget(self.stream_table)
+            actions = QtWidgets.QHBoxLayout()
+            self.stream_profile_combo = QtWidgets.QComboBox()
+            for key, label in (
+                ("auto", "Automatisch"),
+                ("lan-ultra", "LAN Ultra"),
+                ("smooth", "Fluessig"),
+                ("balanced", "Balance"),
+                ("economy", "Sparsam"),
+                ("survival", "Notfall"),
+            ):
+                self.stream_profile_combo.addItem(label, key)
+            apply_button = QtWidgets.QPushButton("Streamprofil setzen")
+            apply_button.clicked.connect(self.set_selected_stream_profile)
+            restart_button = QtWidgets.QPushButton("Stream neu starten")
+            restart_button.clicked.connect(lambda: self.service_action("stream", "restart"))
+            actions.addWidget(self.stream_profile_combo)
+            actions.addWidget(apply_button)
+            actions.addWidget(restart_button)
+            actions.addStretch(1)
+            layout.addLayout(actions)
+
+        def _build_services(self) -> None:
+            layout = QtWidgets.QVBoxLayout(self.services)
+            self.service_table = QtWidgets.QTableWidget(0, 4)
+            self.service_table.setHorizontalHeaderLabels(["Dienst", "Unit", "Aktiv", "Aktiviert"])
+            self.service_table.horizontalHeader().setStretchLastSection(True)
+            self.service_table.verticalHeader().setVisible(False)
+            self.service_table.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
+            layout.addWidget(self.service_table)
+            actions = QtWidgets.QHBoxLayout()
+            self.service_combo = QtWidgets.QComboBox()
+            for key in ("stream", "usb_tunnel", "camera_stream", "netbridge_agent"):
+                self.service_combo.addItem(service_label(key), key)
+            actions.addWidget(self.service_combo)
+            start = QtWidgets.QPushButton("Starten")
+            start.clicked.connect(lambda: self.service_action(self.service_combo.currentData(), "start"))
+            restart = QtWidgets.QPushButton("Neu starten")
+            restart.clicked.connect(lambda: self.service_action(self.service_combo.currentData(), "restart"))
+            actions.addWidget(start)
+            actions.addWidget(restart)
+            actions.addStretch(1)
+            layout.addLayout(actions)
+
+        def _build_usb(self) -> None:
+            layout = QtWidgets.QVBoxLayout(self.usb)
+            self.usb_table = QtWidgets.QTableWidget(0, 5)
+            self.usb_table.setHorizontalHeaderLabels(["Bus-ID", "Name", "Hersteller", "Exportiert", "Klasse"])
+            self.usb_table.horizontalHeader().setStretchLastSection(True)
+            self.usb_table.verticalHeader().setVisible(False)
+            self.usb_table.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
+            layout.addWidget(self.usb_table)
+            actions = QtWidgets.QHBoxLayout()
+            self.usb_busid = QtWidgets.QLineEdit()
+            self.usb_busid.setPlaceholderText("Bus-ID, z. B. 1-2")
+            bind = QtWidgets.QPushButton("Fuer VM freigeben")
+            bind.clicked.connect(lambda: self.usb_action("bind"))
+            unbind = QtWidgets.QPushButton("Vom VM-Tunnel loesen")
+            unbind.clicked.connect(lambda: self.usb_action("unbind"))
+            actions.addWidget(self.usb_busid, 1)
+            actions.addWidget(bind)
+            actions.addWidget(unbind)
+            layout.addLayout(actions)
+            self.av_table = QtWidgets.QTableWidget(0, 3)
+            self.av_table.setHorizontalHeaderLabels(["Typ", "Geraet", "Detail"])
+            self.av_table.horizontalHeader().setStretchLastSection(True)
+            self.av_table.verticalHeader().setVisible(False)
+            self.av_table.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
+            layout.addWidget(self.av_table)
+
+        def _build_devices(self) -> None:
+            layout = QtWidgets.QVBoxLayout(self.devices)
+            self.device_table = QtWidgets.QTableWidget(0, 6)
+            self.device_table.setHorizontalHeaderLabels(["Name", "Adresse", "Art", "Queue", "CUPS", "Manuell"])
+            self.device_table.horizontalHeader().setStretchLastSection(True)
+            self.device_table.verticalHeader().setVisible(False)
+            self.device_table.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
+            layout.addWidget(self.device_table)
+            actions = QtWidgets.QHBoxLayout()
+            for text, slot in (
+                ("Geraete suchen", self.rescan_devices),
+                ("Geraet hinzufuegen", self.add_device),
+                ("Ausgewaehltes Geraet entfernen", self.remove_selected_device),
+                ("Testseite drucken", self.print_selected_device),
+                ("CUPS oeffnen", self.open_cups),
+            ):
+                button = QtWidgets.QPushButton(text)
+                button.clicked.connect(slot)
+                actions.addWidget(button)
+            actions.addStretch(1)
+            layout.addLayout(actions)
+
+        def _build_network(self) -> None:
+            layout = QtWidgets.QVBoxLayout(self.network)
+            self.network_table = QtWidgets.QTableWidget(0, 6)
+            self.network_table.setHorizontalHeaderLabels(["Interface", "Status", "IPv4", "MAC", "Speed", "WLAN"])
+            self.network_table.horizontalHeader().setStretchLastSection(True)
+            self.network_table.verticalHeader().setVisible(False)
+            self.network_table.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
+            layout.addWidget(self.network_table)
+
+        def _build_diagnostics(self) -> None:
+            layout = QtWidgets.QVBoxLayout(self.diagnostics)
+            self.diagnostics_text = QtWidgets.QPlainTextEdit()
+            self.diagnostics_text.setReadOnly(True)
+            self.diagnostics_text.setLineWrapMode(QtWidgets.QPlainTextEdit.NoWrap)
+            layout.addWidget(self.diagnostics_text)
+            actions = QtWidgets.QHBoxLayout()
+            copy_button = QtWidgets.QPushButton("Diagnose in Zwischenablage")
+            copy_button.clicked.connect(self.copy_diagnostics)
+            actions.addWidget(copy_button)
+            actions.addStretch(1)
+            layout.addLayout(actions)
+
+        def _apply_style(self) -> None:
+            self.setStyleSheet(
+                """
+                QMainWindow { background: #f6f7f9; }
+                QLabel#appTitle { font-size: 22px; font-weight: 700; color: #162033; }
+                QGroupBox { border: 1px solid #cfd6df; border-radius: 6px; margin-top: 12px; padding: 10px; font-weight: 700; }
+                QGroupBox::title { subcontrol-origin: margin; left: 10px; padding: 0 4px; }
+                QTabWidget::pane { border: 1px solid #cfd6df; background: #ffffff; }
+                QTabBar::tab { padding: 8px 14px; }
+                QTabBar::tab:selected { background: #ffffff; border: 1px solid #cfd6df; border-bottom: 0; }
+                QTableWidget { background: #ffffff; gridline-color: #e3e7ed; selection-background-color: #dce9ff; }
+                QHeaderView::section { background: #eef2f6; padding: 6px; border: 0; font-weight: 600; }
+                QPushButton { padding: 7px 12px; border: 1px solid #b8c2cf; border-radius: 4px; background: #ffffff; }
+                QPushButton:hover { background: #eef5ff; }
+                QLineEdit, QComboBox { padding: 6px; border: 1px solid #b8c2cf; border-radius: 4px; background: #ffffff; }
+                """
+            )
+
+        def refresh(self) -> None:
+            if self._busy:
+                return
+            self._busy = True
+            self.refresh_button.setEnabled(False)
+            self.status_label.setText("Laedt Thinclient-Status ...")
+            threading.Thread(target=self._refresh_worker, daemon=True).start()
+
+        def _refresh_worker(self) -> None:
+            try:
+                catalog = self.control.status()
+                if catalog is None:
+                    catalog = self.control.catalog()
+                wired = backend.cups_managed_queues()
+                updates = backend.guest_update_snapshot()
+            except Exception:
+                catalog, wired, updates = None, {}, backend.guest_update_snapshot()
+            self.dataReady.emit(catalog, wired, updates)
+
+        def _run_action(self, label: str, op) -> None:
+            def work() -> None:
+                ok = True
+                try:
+                    message = op()
+                except Exception as exc:
+                    ok = False
+                    message = str(exc)
+                self.actionDone.emit(label, str(message or "Fertig."), ok)
+                self._refresh_worker()
+
+            threading.Thread(target=work, daemon=True).start()
+
+        def _show_action_result(self, label: str, message: str, ok: bool) -> None:
+            icon = QtWidgets.QMessageBox.Information if ok else QtWidgets.QMessageBox.Warning
+            QtWidgets.QMessageBox(icon, label, message, QtWidgets.QMessageBox.Ok, self).show()
+
+        def _render(self, catalog, wired, updates) -> None:
+            self._busy = False
+            self.refresh_button.setEnabled(True)
+            self.catalog = catalog if isinstance(catalog, dict) else None
+            self.wired = wired if isinstance(wired, dict) else {}
+            self.update_status = updates if isinstance(updates, dict) else {}
+            agent = self.catalog.get("agent_host", "?") if self.catalog else "nicht erreichbar"
+            self.status_label.setText(f"Agent: {agent} | {time.strftime('%H:%M:%S')}")
+            self._render_overview()
+            self._render_updates()
+            self._render_stream()
+            self._render_services()
+            self._render_usb_av()
+            self._render_devices()
+            self._render_network()
+            self._render_diagnostics()
+
+        def _set_rows(self, table, rows: list[list[object]]) -> None:
+            table.setRowCount(len(rows))
+            for row_index, row in enumerate(rows):
+                for col_index, value in enumerate(row):
+                    item = QtWidgets.QTableWidgetItem(compact(value))
+                    if col_index == 0:
+                        item.setData(QtCore.Qt.UserRole, value)
+                    table.setItem(row_index, col_index, item)
+            table.resizeColumnsToContents()
+
+        def thinclient(self) -> dict:
+            if not self.catalog:
+                return {}
+            value = self.catalog.get("thinclient", {})
+            return value if isinstance(value, dict) else {}
+
+        def _render_overview(self) -> None:
+            thin = self.thinclient()
+            stream = thin.get("stream", {}) if isinstance(thin.get("stream"), dict) else {}
+            services = thin.get("services", {}) if isinstance(thin.get("services"), dict) else {}
+            usb = thin.get("usb", {}) if isinstance(thin.get("usb"), dict) else {}
+            thin_update = thin.get("update", {}) if isinstance(thin.get("update"), dict) else {}
+            devices = self.catalog.get("devices", []) if self.catalog else []
+            updates = self.update_status
+            rows = [
+                ["Agent", self.catalog.get("agent_host", "nicht erreichbar") if self.catalog else "nicht erreichbar"],
+                ["Streamprofil", stream.get("profile", "-")],
+                ["Geraete", len(devices)],
+                ["CUPS-Queues", len(self.wired)],
+                ["USB-Tunnel", usb.get("tunnel_state", "-")],
+                ["VM-Update", update_state_label(updates)],
+                ["VM-Neustartziel", reboot_target_label(updates, "Diese VM")],
+                ["Thinclient-Update", update_state_label(thin_update)],
+                ["Thinclient-Neustartziel", reboot_target_label(thin_update, "Thinclient")],
+                ["Dienste aktiv", sum(1 for item in services.values() if isinstance(item, dict) and item.get("active") == "active")],
+            ]
+            self._set_rows(self.overview_grid, rows)
+
+        def _render_updates(self) -> None:
+            status = self.update_status
+            profile = status.get("desktop_profile", {}) if isinstance(status.get("desktop_profile"), dict) else {}
+            rows = [
+                ["Status", status.get("state", "unknown")],
+                ["Installiert", status.get("current_version", "-")],
+                ["Remote", status.get("latest_version", "-")],
+                ["Update verfuegbar", "ja" if status.get("available") else "nein"],
+                ["Desktop-Profil verfuegbar", "ja" if status.get("desktop_profile_available") else "nein"],
+                ["Desktop-Profil", status.get("desktop_profile_version") or profile.get("profile_version") or "-"],
+                ["Neustart erforderlich", "ja" if status.get("pending_reboot") else "nein"],
+                ["Neustart betrifft", reboot_target_label(status, "Diese VM")],
+                ["Hinweis", status.get("last_error") or profile.get("last_error") or "-"],
+            ]
+            self._set_rows(self.update_grid, rows)
+            thin_status = self.thinclient().get("update", {})
+            if not isinstance(thin_status, dict):
+                thin_status = {}
+            thin_rows = [
+                ["Status", thin_status.get("state", "unknown")],
+                ["Installiert", thin_status.get("current_version") or thin_status.get("installed_version") or "-"],
+                ["Remote", thin_status.get("latest_version") or thin_status.get("staged_version") or "-"],
+                ["Update verfuegbar", "ja" if thin_status.get("available") or thin_status.get("state") in {"staged", "reboot-required"} else "nein"],
+                ["Slot aktuell", thin_status.get("current_slot", "-")],
+                ["Slot naechster Start", thin_status.get("next_slot") or thin_status.get("staged_slot") or "-"],
+                ["Neustart erforderlich", "ja" if thin_status.get("pending_reboot") else "nein"],
+                ["Neustart betrifft", reboot_target_label(thin_status, "Thinclient")],
+                ["Hinweis", thin_status.get("last_error", "-")],
+            ]
+            self._set_rows(self.thin_update_grid, thin_rows)
+
+        def _render_stream(self) -> None:
+            stream = self.thinclient().get("stream", {})
+            if not isinstance(stream, dict):
+                stream = {}
+            auto = stream.get("auto_quality", {}) if isinstance(stream.get("auto_quality"), dict) else {}
+            values = stream.get("values", {}) if isinstance(stream.get("values"), dict) else {}
+            rows = [
+                ["Aktives Profil", stream.get("profile", "-")],
+                ["Profil-Datei", stream.get("profile_file", "-")],
+                ["Auto-Bucket", auto.get("bucket", "-")],
+                ["RTT Durchschnitt", auto.get("rtt_avg_ms", "-")],
+                ["Paketverlust", auto.get("loss", "-")],
+                ["Geprueft", auto.get("checked_at", "-")],
+            ]
+            for key in ("resolution", "fps", "bitrate", "packet_size", "frame_pacing", "vsync", "video_decoder", "display_mode"):
+                if key in values:
+                    rows.append([key, values.get(key)])
+            self._set_rows(self.stream_table, rows)
+
+        def _render_services(self) -> None:
+            services = self.thinclient().get("services", {})
+            if not isinstance(services, dict):
+                services = {}
+            rows = []
+            for key in sorted(services):
+                state = services.get(key, {}) if isinstance(services.get(key), dict) else {}
+                rows.append([service_label(key), state.get("unit", key), state.get("active", "-"), state.get("enabled", "-")])
+            self._set_rows(self.service_table, rows)
+
+        def _render_usb_av(self) -> None:
+            thin = self.thinclient()
+            usb = thin.get("usb", {}) if isinstance(thin.get("usb"), dict) else {}
+            devices = usb.get("devices", []) if isinstance(usb.get("devices"), list) else []
+            self._set_rows(self.usb_table, [
+                [
+                    item.get("busid", item.get("id", "")),
+                    item.get("product") or item.get("name") or "-",
+                    item.get("manufacturer", "-"),
+                    "ja" if item.get("bound") or item.get("exported") else "nein",
+                    item.get("class", "-"),
+                ]
+                for item in devices if isinstance(item, dict)
+            ])
+            rows = []
+            audio = thin.get("audio", {}) if isinstance(thin.get("audio"), dict) else {}
+            for item in audio.get("capture_devices", []) or []:
+                if isinstance(item, dict):
+                    rows.append(["Mikrofon", item.get("name") or item.get("summary") or item.get("id") or "-", json.dumps(item, ensure_ascii=False)])
+            video = thin.get("video", {}) if isinstance(thin.get("video"), dict) else {}
+            for item in video.get("devices", []) or []:
+                if isinstance(item, dict):
+                    rows.append(["Webcam", item.get("name") or item.get("node") or "-", json.dumps(item, ensure_ascii=False)])
+            self._set_rows(self.av_table, rows)
+
+        def _render_devices(self) -> None:
+            devices = self.catalog.get("devices", []) if self.catalog else []
+            rows = []
+            for device in devices:
+                if not isinstance(device, dict):
+                    continue
+                queue = backend.queue_name(device)
+                rows.append([
+                    device.get("name") or device.get("id") or "-",
+                    device.get("address", "-"),
+                    device.get("kind", "-"),
+                    queue,
+                    "ja" if queue in self.wired else "nein",
+                    "ja" if device.get("manual") else "nein",
+                ])
+            self._set_rows(self.device_table, rows)
+
+        def _render_network(self) -> None:
+            network = self.thinclient().get("network", {})
+            interfaces = network.get("interfaces", []) if isinstance(network, dict) else []
+            self._set_rows(self.network_table, [
+                [
+                    item.get("name", "-"),
+                    item.get("state", "-"),
+                    item.get("ipv4", "-"),
+                    item.get("mac", "-"),
+                    item.get("speed_mbps", "-"),
+                    "ja" if item.get("wireless") else "nein",
+                ]
+                for item in interfaces if isinstance(item, dict)
+            ])
+
+        def _render_diagnostics(self) -> None:
+            payload = {
+                "vm_update": self.update_status,
+                "thinclient": self.thinclient(),
+                "netbridge": {
+                    "agent_host": self.catalog.get("agent_host") if self.catalog else "",
+                    "devices": self.catalog.get("devices", []) if self.catalog else [],
+                    "cups_queues": self.wired,
+                },
+            }
+            self.diagnostics_text.setPlainText(json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False))
+
+        def selected_device(self) -> dict | None:
+            row = self.device_table.currentRow()
+            if row < 0 or not self.catalog:
+                return None
+            name = self.device_table.item(row, 0).text() if self.device_table.item(row, 0) else ""
+            address = self.device_table.item(row, 1).text() if self.device_table.item(row, 1) else ""
+            for device in self.catalog.get("devices", []):
+                if not isinstance(device, dict):
+                    continue
+                if (device.get("name") or device.get("id") or "-") == name and compact(device.get("address", "-")) == address:
+                    return device
+            return None
+
+        def scan_updates(self) -> None:
+            def op() -> str:
+                ok, message, status = backend.run_guest_updater(["scan", "--force"])
+                if not ok:
+                    raise RuntimeError(message)
+                return "Update verfuegbar." if status.get("available") or status.get("desktop_profile_available") else "System ist aktuell."
+            self._run_action("UpdateCenter", op)
+
+        def apply_updates(self) -> None:
+            def op() -> str:
+                ok, message, status = backend.run_guest_updater(["apply", "--reboot"])
+                if not ok:
+                    raise RuntimeError(message)
+                return "Update installiert. Neustart erforderlich." if status.get("pending_reboot") else "Update installiert."
+            self._run_action("UpdateCenter", op)
+
+        def refresh_desktop_profile(self) -> None:
+            def op() -> str:
+                ok, message, _status = backend.run_guest_updater(["desktop-profile-refresh", "--force"])
+                if not ok:
+                    raise RuntimeError(message)
+                return "Desktop-Profil wurde erneuert."
+            self._run_action("UpdateCenter", op)
+
+        def thinclient_update_action(self, action: str) -> None:
+            if action in {"apply", "rollback"}:
+                verb = "installieren und den Thinclient neu starten" if action == "apply" else "zurueckrollen und den Thinclient neu starten"
+                if not self.confirm("Thinclient-Update", f"Thinclient-Update wirklich {verb}?"):
+                    return
+
+            def op() -> str:
+                result = self.control.thinclient_update(action)
+                if result is None:
+                    raise RuntimeError("Agent nicht erreichbar.")
+                if not result.get("ok"):
+                    raise RuntimeError(str(result.get("error", "unbekannter Fehler")))
+                update = result.get("update", {}) if isinstance(result.get("update"), dict) else {}
+                if update.get("pending_reboot"):
+                    return "Thinclient-Update vorbereitet. Neustartziel: Thinclient."
+                return f"Thinclient-Updateaktion abgeschlossen: {action}."
+            self._run_action("Thinclient-Update", op)
+
+        def vm_power_action(self, action: str) -> None:
+            label = "neu starten" if action == "reboot" else "herunterfahren"
+            if not self.confirm("Diese VM", f"Diese VM wirklich {label}? Der Thinclient bleibt eingeschaltet."):
+                return
+
+            def op() -> str:
+                ok, message, _status = backend.run_guest_updater([action])
+                if not ok:
+                    raise RuntimeError(message)
+                return f"Diese VM wird {label}."
+            self._run_action("Diese VM", op)
+
+        def thinclient_power_action(self, action: str) -> None:
+            label = "neu starten" if action == "reboot" else "herunterfahren"
+            if not self.confirm("Thinclient", f"Thinclient wirklich {label}? Dadurch endet die VM-Sitzung am Arbeitsplatz."):
+                return
+
+            def op() -> str:
+                result = self.control.thinclient_power(action)
+                if result is None:
+                    raise RuntimeError("Agent nicht erreichbar.")
+                if not result.get("ok"):
+                    raise RuntimeError(str(result.get("error", "unbekannter Fehler")))
+                return f"Thinclient wird {label}."
+            self._run_action("Thinclient", op)
+
+        def service_action(self, service: str, action: str) -> None:
+            def op() -> str:
+                result = self.control.service_action(service, action)
+                if result is None:
+                    raise RuntimeError("Agent nicht erreichbar.")
+                if not result.get("ok"):
+                    raise RuntimeError(str(result.get("error", "unbekannter Fehler")))
+                return f"{service_label(service)}: {action} ausgefuehrt."
+            self._run_action("Dienststeuerung", op)
+
+        def restart_agent(self) -> None:
+            def op() -> str:
+                result = self.control.restart_agent()
+                if result is None:
+                    raise RuntimeError("Agent nicht erreichbar.")
+                if not result.get("ok"):
+                    raise RuntimeError(str(result.get("error", "unbekannter Fehler")))
+                time.sleep(1)
+                return "Agent-Neustart ausgeloest."
+            self._run_action("NetBridge Agent", op)
+
+        def set_selected_stream_profile(self) -> None:
+            profile = str(self.stream_profile_combo.currentData() or "auto")
+
+            def op() -> str:
+                result = self.control.set_stream_profile(profile)
+                if result is None:
+                    raise RuntimeError("Agent nicht erreichbar.")
+                if not result.get("ok"):
+                    raise RuntimeError(str(result.get("error", "unbekannter Fehler")))
+                return f"Streamprofil gesetzt: {profile}. Falls bereits eine Sitzung laeuft, Stream neu starten."
+            self._run_action("Stream", op)
+
+        def usb_action(self, action: str) -> None:
+            busid = self.usb_busid.text().strip()
+            if not busid and self.usb_table.currentRow() >= 0 and self.usb_table.item(self.usb_table.currentRow(), 0):
+                busid = self.usb_table.item(self.usb_table.currentRow(), 0).text().strip()
+            if not busid:
+                QtWidgets.QMessageBox.warning(self, "USB", "Bitte eine Bus-ID auswaehlen oder eingeben.")
+                return
+
+            def op() -> str:
+                result = self.control.usb_bind(busid) if action == "bind" else self.control.usb_unbind(busid)
+                if result is None:
+                    raise RuntimeError("Agent nicht erreichbar.")
+                if not result.get("ok"):
+                    raise RuntimeError(str(result.get("error", "unbekannter Fehler")))
+                return f"USB {busid} wurde aktualisiert."
+            self._run_action("USB", op)
+
+        def rescan_devices(self) -> None:
+            def op() -> str:
+                result = self.control.rescan()
+                if result is None:
+                    raise RuntimeError("Agent nicht erreichbar.")
+                return f"Suche abgeschlossen: {len(result.get('devices', []))} Geraet(e)."
+            self._run_action("LAN-Geraete", op)
+
+        def add_device(self) -> None:
+            dialog = AddDeviceDialog(self)
+            if dialog.exec_() != QtWidgets.QDialog.Accepted:
+                return
+            values = dialog.values()
+            if not values["address"]:
+                QtWidgets.QMessageBox.warning(self, "LAN-Geraete", "Bitte eine Adresse angeben.")
+                return
+
+            def op() -> str:
+                result = self.control.add_static(values["address"], values["port"], values["name"], values["rp"])
+                if result is None:
+                    raise RuntimeError("Agent nicht erreichbar.")
+                if not result.get("ok"):
+                    raise RuntimeError(str(result.get("error", "unbekannter Fehler")))
+                return "Geraet wurde hinzugefuegt."
+            self._run_action("LAN-Geraete", op)
+
+        def remove_selected_device(self) -> None:
+            device = self.selected_device()
+            if not device or not device.get("manual"):
+                QtWidgets.QMessageBox.information(self, "LAN-Geraete", "Bitte ein manuelles Geraet auswaehlen.")
+                return
+            device_id = str(device.get("id", ""))
+
+            def op() -> str:
+                result = self.control.remove_static(device_id)
+                if result is None:
+                    raise RuntimeError("Agent nicht erreichbar.")
+                if not result.get("ok"):
+                    raise RuntimeError(str(result.get("error", "unbekannter Fehler")))
+                return "Geraet wurde entfernt."
+            self._run_action("LAN-Geraete", op)
+
+        def print_selected_device(self) -> None:
+            device = self.selected_device()
+            if not device:
+                QtWidgets.QMessageBox.information(self, "LAN-Geraete", "Bitte ein Geraet auswaehlen.")
+                return
+            queue = backend.queue_name(device)
+
+            def op() -> str:
+                ok, message = backend.print_test_page(queue)
+                if not ok:
+                    raise RuntimeError(message)
+                return message or f"Testseite an {queue} gesendet."
+            self._run_action("Drucken", op)
+
+        def open_cups(self) -> None:
+            QtGui.QDesktopServices.openUrl(QtCore.QUrl("http://localhost:631/printers/"))
+
+        def confirm(self, title: str, message: str) -> bool:
+            result = QtWidgets.QMessageBox.question(
+                self,
+                title,
+                message,
+                QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
+                QtWidgets.QMessageBox.No,
+            )
+            return result == QtWidgets.QMessageBox.Yes
+
+        def copy_diagnostics(self) -> None:
+            QtWidgets.QApplication.clipboard().setText(self.diagnostics_text.toPlainText())
+            self.status_label.setText("Diagnose kopiert")
+
+    app = QtWidgets.QApplication(sys.argv)
+    app.setApplicationName(APP_NAME)
+    app.setApplicationDisplayName(APP_NAME)
+    app.setDesktopFileName(APP_ID)
+    window = AdminWindow()
+    window.show()
+    return app.exec_()
+
+
+def selftest() -> int:
+    control = backend.NetBridgeControl()
+    print(f"backend: {backend.__file__}")
+    print(f"agent endpoints: {control.endpoints}")
+    print(f"update_state: {backend.guest_update_snapshot().get('state', 'unknown')}")
+    print("RESULT: ok")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = argv if argv is not None else sys.argv[1:]
+    if "--selftest" in argv:
+        return selftest()
+    return run_app()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/beagle-host/netbridge/beagle-thinclient-admin.desktop
+++ b/beagle-host/netbridge/beagle-thinclient-admin.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=Beagle Thinclient Verwaltung
+GenericName=Thinclient system manager
+Comment=Manage thin-client updates, services, USB devices and shared LAN devices
+Exec=/usr/local/bin/beagle-thinclient-admin
+Icon=beagle-netbridge-tray
+Terminal=false
+Categories=Utility;System;HardwareSettings;
+StartupNotify=true

--- a/beagle-host/services/service_registry.py
+++ b/beagle-host/services/service_registry.py
@@ -3048,6 +3048,8 @@ def ubuntu_beagle_provisioning_service() -> UbuntuBeagleProvisioningService:
             build_profile=build_profile,
             beagle_desktop_profile_refresh_script=ROOT_DIR / "beagle-host" / "bin" / "beagle-desktop-profile-refresh",
             beagle_guest_updater_script=ROOT_DIR / "beagle-host" / "bin" / "beagle-guest-updater",
+            beagle_thinclient_admin_desktop_file=ROOT_DIR / "beagle-host" / "netbridge" / "beagle-thinclient-admin.desktop",
+            beagle_thinclient_admin_script=ROOT_DIR / "beagle-host" / "netbridge" / "beagle-thinclient-admin",
             beagle_netbridge_tray_script=ROOT_DIR / "beagle-host" / "netbridge" / "beagle-netbridge-tray",
             configure_beagle_stream_server_guest_script=ROOT_DIR / "scripts" / "configure-beagle-stream-server-guest.sh",
             current_public_stream_host=current_public_stream_host,

--- a/beagle-host/services/ubuntu_beagle_provisioning.py
+++ b/beagle-host/services/ubuntu_beagle_provisioning.py
@@ -28,6 +28,8 @@ class UbuntuBeagleProvisioningService:
         build_profile: Callable[[Any], dict[str, Any]],
         beagle_desktop_profile_refresh_script: Path,
         beagle_guest_updater_script: Path,
+        beagle_thinclient_admin_desktop_file: Path,
+        beagle_thinclient_admin_script: Path,
         beagle_netbridge_tray_script: Path,
         configure_beagle_stream_server_guest_script: Path,
         current_public_stream_host: Callable[[], str],
@@ -101,6 +103,8 @@ class UbuntuBeagleProvisioningService:
         self._build_profile = build_profile
         self._beagle_desktop_profile_refresh_script = Path(beagle_desktop_profile_refresh_script)
         self._beagle_guest_updater_script = Path(beagle_guest_updater_script)
+        self._beagle_thinclient_admin_desktop_file = Path(beagle_thinclient_admin_desktop_file)
+        self._beagle_thinclient_admin_script = Path(beagle_thinclient_admin_script)
         self._beagle_netbridge_tray_script = Path(beagle_netbridge_tray_script)
         self._configure_beagle_stream_server_guest_script = Path(configure_beagle_stream_server_guest_script)
         self._current_public_stream_host = current_public_stream_host
@@ -877,6 +881,8 @@ class UbuntuBeagleProvisioningService:
         desktop_theme_variant = str(desktop.get("theme_variant", desktop["id"])).strip()
         desktop_profile_refresh_b64 = base64.b64encode(self._beagle_desktop_profile_refresh_script.read_bytes()).decode("ascii")
         guest_updater_b64 = base64.b64encode(self._beagle_guest_updater_script.read_bytes()).decode("ascii")
+        thinclient_admin_b64 = base64.b64encode(self._beagle_thinclient_admin_script.read_bytes()).decode("ascii")
+        thinclient_admin_desktop_b64 = base64.b64encode(self._beagle_thinclient_admin_desktop_file.read_bytes()).decode("ascii")
         netbridge_tray_b64 = base64.b64encode(self._beagle_netbridge_tray_script.read_bytes()).decode("ascii")
 
         firstboot_script = self.render_template_file(
@@ -890,6 +896,8 @@ class UbuntuBeagleProvisioningService:
                 "__BEAGLE_VERSION__": self._version,
             "__BEAGLE_DESKTOP_PROFILE_REFRESH_B64__": desktop_profile_refresh_b64,
             "__BEAGLE_GUEST_UPDATER_B64__": guest_updater_b64,
+            "__BEAGLE_THINCLIENT_ADMIN_B64__": thinclient_admin_b64,
+            "__BEAGLE_THINCLIENT_ADMIN_DESKTOP_B64__": thinclient_admin_desktop_b64,
             "__BEAGLE_NETBRIDGE_TRAY_B64__": netbridge_tray_b64,
                 "__BEAGLE_STREAM_SERVER_USER__": beagle_stream_server_user,
                 "__BEAGLE_STREAM_SERVER_PASSWORD__": beagle_stream_server_password,

--- a/beagle-host/templates/ubuntu-beagle/firstboot-provision.sh.tpl
+++ b/beagle-host/templates/ubuntu-beagle/firstboot-provision.sh.tpl
@@ -11,6 +11,8 @@ BEAGLE_ENDPOINT_TOKEN="__BEAGLE_ENDPOINT_TOKEN__"
 BEAGLE_VERSION="__BEAGLE_VERSION__"
 BEAGLE_GUEST_UPDATER_B64="__BEAGLE_GUEST_UPDATER_B64__"
 BEAGLE_DESKTOP_PROFILE_REFRESH_B64="__BEAGLE_DESKTOP_PROFILE_REFRESH_B64__"
+BEAGLE_THINCLIENT_ADMIN_B64="__BEAGLE_THINCLIENT_ADMIN_B64__"
+BEAGLE_THINCLIENT_ADMIN_DESKTOP_B64="__BEAGLE_THINCLIENT_ADMIN_DESKTOP_B64__"
 BEAGLE_NETBRIDGE_TRAY_B64="__BEAGLE_NETBRIDGE_TRAY_B64__"
 IDENTITY_LOCALE="__IDENTITY_LOCALE__"
 IDENTITY_LANGUAGE="__IDENTITY_LANGUAGE__"
@@ -94,7 +96,7 @@ BEAGLE_GUEST_UPDATER_INTERACTIVE_REBOOT=1
 EOF
   chmod 0600 /etc/beagle/guest-updater.env
   cat > /etc/sudoers.d/beagle-guest-updater <<EOF
-${GUEST_USER} ALL=(root) NOPASSWD: /usr/local/sbin/beagle-guest-updater status, /usr/local/sbin/beagle-guest-updater scan --force, /usr/local/sbin/beagle-guest-updater apply --reboot, /usr/local/sbin/beagle-guest-updater desktop-profile-refresh --force
+${GUEST_USER} ALL=(root) NOPASSWD: /usr/local/sbin/beagle-guest-updater status, /usr/local/sbin/beagle-guest-updater scan --force, /usr/local/sbin/beagle-guest-updater apply --reboot, /usr/local/sbin/beagle-guest-updater desktop-profile-refresh --force, /usr/local/sbin/beagle-guest-updater reboot, /usr/local/sbin/beagle-guest-updater shutdown
 EOF
   chmod 0440 /etc/sudoers.d/beagle-guest-updater
   cat > /etc/systemd/system/beagle-guest-updater-scan.service <<'EOF'
@@ -3229,6 +3231,9 @@ MANAGED_PREFIX = "beagle-net-"
 CONTROL_TIMEOUT = 6
 APP_ID = "com.beagle-os.netbridge.tray"
 APP_NAME = "Beagle NetBridge"
+ADMIN_APP_PATHS = (
+    "/usr/local/bin/beagle-thinclient-admin",
+)
 ICON_PATHS = (
     "/usr/local/share/beagle/beagle-netbridge-tray.png",
     "/usr/local/share/icons/hicolor/256x256/apps/beagle-netbridge-tray.png",
@@ -3337,6 +3342,12 @@ class NetBridgeControl:
 
     def service_action(self, service: str, action: str = "restart") -> dict | None:
         return self.request("service_action", service=service, action=action)
+
+    def thinclient_update(self, action: str = "status") -> dict | None:
+        return self.request("thinclient_update", action=action)
+
+    def thinclient_power(self, action: str) -> dict | None:
+        return self.request("thinclient_power", action=action)
 
     def usb_bind(self, busid: str) -> dict | None:
         return self.request("usb_bind", busid=busid)
@@ -3644,6 +3655,7 @@ def run_tray() -> int:
                     self._add_device_menu(device)
 
             self.menu.addSeparator()
+            self.menu.addAction("Thinclient Verwaltung öffnen", self.action_open_admin)
             self.menu.addAction("Geräte suchen…", self.action_rescan)
             self.menu.addAction("Gerät hinzufügen…", self.action_add)
             self.menu.addAction("Druckerverwaltung öffnen", self.action_open_cups)
@@ -3841,6 +3853,16 @@ def run_tray() -> int:
         def action_open_cups(self) -> None:
             QtGui.QDesktopServices.openUrl(QtCore.QUrl("http://localhost:631/printers/"))
 
+        def action_open_admin(self) -> None:
+            for candidate in ADMIN_APP_PATHS:
+                if os.access(candidate, os.X_OK):
+                    try:
+                        subprocess.Popen([candidate], close_fds=True)
+                    except OSError as exc:
+                        self._notify(APP_NAME, f"Thinclient Verwaltung konnte nicht gestartet werden: {exc}")
+                    return
+            self._notify(APP_NAME, "Thinclient Verwaltung ist nicht installiert.")
+
         def action_set_stream_profile(self, profile: str) -> None:
             def op():
                 result = self.control.set_stream_profile(profile)
@@ -3914,6 +3936,48 @@ NETBRIDGETRAYEOF
       printf '%s' "$BEAGLE_NETBRIDGE_TRAY_B64" | base64 -d > /usr/local/bin/beagle-netbridge-tray
     fi
     chmod 0755 /usr/local/bin/beagle-netbridge-tray
+
+    cat > /usr/local/bin/beagle-thinclient-admin <<'THINCLIENTADMINEOF'
+#!/usr/bin/env python3
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+import subprocess
+import sys
+
+tray = Path("/usr/local/bin/beagle-netbridge-tray")
+if not tray.is_file():
+    raise SystemExit("beagle-netbridge-tray backend not installed")
+backend = SourceFileLoader("beagle_netbridge_tray_admin_fallback", str(tray)).load_module()
+if "--selftest" in sys.argv[1:]:
+    print(f"backend: {backend.__file__}")
+    print("RESULT: ok")
+    raise SystemExit(0)
+if Path("/usr/bin/systemsettings").exists():
+    subprocess.Popen(["/usr/bin/systemsettings"], close_fds=True)
+    raise SystemExit(0)
+raise SystemExit("full beagle-thinclient-admin payload was not embedded")
+THINCLIENTADMINEOF
+    if [[ -n "$BEAGLE_THINCLIENT_ADMIN_B64" ]]; then
+      printf '%s' "$BEAGLE_THINCLIENT_ADMIN_B64" | base64 -d > /usr/local/bin/beagle-thinclient-admin
+    fi
+    chmod 0755 /usr/local/bin/beagle-thinclient-admin
+
+    install -d -m 0755 /usr/local/share/applications
+    cat > /usr/local/share/applications/beagle-thinclient-admin.desktop <<'EOF'
+[Desktop Entry]
+Type=Application
+Name=Beagle Thinclient Verwaltung
+GenericName=Thinclient system manager
+Comment=Manage thin-client updates, services, USB devices and shared LAN devices
+Exec=/usr/local/bin/beagle-thinclient-admin
+Icon=beagle-netbridge-tray
+Terminal=false
+Categories=Utility;System;HardwareSettings;
+StartupNotify=true
+EOF
+    if [[ -n "$BEAGLE_THINCLIENT_ADMIN_DESKTOP_B64" ]]; then
+      printf '%s' "$BEAGLE_THINCLIENT_ADMIN_DESKTOP_B64" | base64 -d > /usr/local/share/applications/beagle-thinclient-admin.desktop
+    fi
     python3 - "${BEAGLE_WALLPAPER_PATH:-}" <<'PY' || true
 import os
 import sys

--- a/beagle-os/overlay/usr/local/sbin/beagle-egress-apply
+++ b/beagle-os/overlay/usr/local/sbin/beagle-egress-apply
@@ -35,31 +35,6 @@ wg_endpoint="${BEAGLE_ENDPOINT_EGRESS_WG_ENDPOINT:-${PVE_THIN_CLIENT_BEAGLE_EGRE
 wg_preshared_key="${BEAGLE_ENDPOINT_EGRESS_WG_PRESHARED_KEY:-${PVE_THIN_CLIENT_BEAGLE_EGRESS_WG_PRESHARED_KEY:-}}"
 wg_keepalive="${BEAGLE_ENDPOINT_EGRESS_WG_PERSISTENT_KEEPALIVE:-${PVE_THIN_CLIENT_BEAGLE_EGRESS_WG_PERSISTENT_KEEPALIVE:-25}}"
 
-if [[ "${PVE_THIN_CLIENT_CONNECTION_METHOD:-}" == "broker" && \
-      -n "${PVE_THIN_CLIENT_BEAGLE_MANAGER_URL:-}" && \
-      "$interface_name" == "wg-beagle" ]]; then
-  install -d -m 0755 "$STATE_DIR"
-  write_status "managed-by-thinclient-runtime" "0" "" ""
-  exit 0
-fi
-
-read_previous_value() {
-  local key="$1"
-  [[ -r "$STATUS_FILE" ]] || return 1
-  awk -F= -v wanted="$key" '$1 == wanted {print substr($0, index($0, "=") + 1); exit}' "$STATUS_FILE"
-}
-
-delete_previous_split_routes() {
-  local previous route
-  previous="$(read_previous_value route_destinations || true)"
-  [[ -n "$previous" ]] || return 0
-  for route in $previous; do
-    ip route del "$route" dev "$interface_name" >/dev/null 2>&1 || true
-  done
-  ip rule del fwmark "$TABLE_ID" table "$TABLE_ID" priority "$TABLE_ID" >/dev/null 2>&1 || true
-  ip route flush table "$TABLE_ID" >/dev/null 2>&1 || true
-}
-
 write_status() {
   local state="$1"
   local route_count="$2"
@@ -79,6 +54,36 @@ write_status() {
     printf 'public_ip=%q\n' "$public_ip"
   } >"$STATUS_FILE"
   chmod 0644 "$STATUS_FILE"
+}
+
+if [[ "$mode" != "direct" && \
+      "$egress_type" == "wireguard" && \
+      -n "${PVE_THIN_CLIENT_BEAGLE_MANAGER_URL:-}" && \
+      "$interface_name" == "wg-beagle" ]]; then
+  install -d -m 0755 "$STATE_DIR"
+  if ip link show "$interface_name" >/dev/null 2>&1; then
+    write_status "managed-by-thinclient-runtime" "0" "" ""
+  else
+    write_status "pending-thinclient-runtime" "0" "" ""
+  fi
+  exit 0
+fi
+
+read_previous_value() {
+  local key="$1"
+  [[ -r "$STATUS_FILE" ]] || return 1
+  awk -F= -v wanted="$key" '$1 == wanted {print substr($0, index($0, "=") + 1); exit}' "$STATUS_FILE"
+}
+
+delete_previous_split_routes() {
+  local previous route
+  previous="$(read_previous_value route_destinations || true)"
+  [[ -n "$previous" ]] || return 0
+  for route in $previous; do
+    ip route del "$route" dev "$interface_name" >/dev/null 2>&1 || true
+  done
+  ip rule del fwmark "$TABLE_ID" table "$TABLE_ID" priority "$TABLE_ID" >/dev/null 2>&1 || true
+  ip route flush table "$TABLE_ID" >/dev/null 2>&1 || true
 }
 
 if [[ "$mode" == "direct" || -z "$egress_type" ]]; then

--- a/beagle-os/overlay/usr/local/sbin/beagle-healthcheck
+++ b/beagle-os/overlay/usr/local/sbin/beagle-healthcheck
@@ -20,6 +20,17 @@ if [[ -r "$COMMON_SH" ]]; then
   load_runtime_config >/dev/null 2>&1 || true
 fi
 
+BEAGLE_STREAM_CLIENT_TARGETING_SH="${BEAGLE_STREAM_CLIENT_TARGETING_SH:-$(runtime_resolve_helper_path beagle_stream_client_targeting.sh 2>/dev/null || true)}"
+BEAGLE_STREAM_CLIENT_API_URL_SH="${BEAGLE_STREAM_CLIENT_API_URL_SH:-$(runtime_resolve_helper_path beagle_stream_client_api_url.sh 2>/dev/null || true)}"
+if [[ -r "${BEAGLE_STREAM_CLIENT_TARGETING_SH:-}" ]]; then
+  # shellcheck disable=SC1090
+  source "$BEAGLE_STREAM_CLIENT_TARGETING_SH"
+fi
+if [[ -r "${BEAGLE_STREAM_CLIENT_API_URL_SH:-}" ]]; then
+  # shellcheck disable=SC1090
+  source "$BEAGLE_STREAM_CLIENT_API_URL_SH"
+fi
+
 beagle_stream_client_host="${BEAGLE_ENDPOINT_BEAGLE_STREAM_CLIENT_HOST:-${PVE_THIN_CLIENT_BEAGLE_STREAM_CLIENT_HOST:-}}"
 beagle_stream_server_api_url="${BEAGLE_ENDPOINT_BEAGLE_STREAM_SERVER_API_URL:-${PVE_THIN_CLIENT_BEAGLE_STREAM_SERVER_API_URL:-}}"
 beagle_stream_server_username="${BEAGLE_ENDPOINT_BEAGLE_STREAM_SERVER_USERNAME:-${PVE_THIN_CLIENT_BEAGLE_STREAM_SERVER_USERNAME:-}}"
@@ -55,6 +66,19 @@ identity_locale="$(awk -F= '$1 == "locale" {print substr($0, index($0, "=") + 1)
 identity_keymap="$(awk -F= '$1 == "keymap" {print substr($0, index($0, "=") + 1); exit}' /var/lib/beagle-os/identity.status 2>/dev/null || true)"
 client_mode="${PVE_THIN_CLIENT_CLIENT_MODE:-$(cmdline_var pve_thin_client.client_mode 2>/dev/null || true)}"
 kiosk_state="$(systemctl is-active beagle-kiosk.service 2>/dev/null || true)"
+
+if declare -F beagle_stream_client_host >/dev/null 2>&1; then
+  resolved_beagle_stream_client_host="$(beagle_stream_client_host 2>/dev/null || true)"
+  if [[ -n "$resolved_beagle_stream_client_host" ]]; then
+    beagle_stream_client_host="$resolved_beagle_stream_client_host"
+  fi
+fi
+if declare -F selected_beagle_stream_server_api_url >/dev/null 2>&1; then
+  resolved_beagle_stream_server_api_url="$(selected_beagle_stream_server_api_url 2>/dev/null || true)"
+  if [[ -n "$resolved_beagle_stream_server_api_url" ]]; then
+    beagle_stream_server_api_url="$resolved_beagle_stream_server_api_url"
+  fi
+fi
 
 if command -v beagle-stream-client >/dev/null 2>&1; then
   beagle_stream_client_binary="1"

--- a/tests/unit/test_auto_pairing_flow.py
+++ b/tests/unit/test_auto_pairing_flow.py
@@ -114,6 +114,7 @@ def _make_surface(
         build_vm_profile=lambda item: {},
         dequeue_vm_actions=lambda node, vmid: [],
         device_registry_service=_DeviceRegistry(),
+        device_log_service=None,
         mdm_policy_service=type("Mdm", (), {"resolve_policy": staticmethod(lambda device_id, group="": _Policy())})(),
         attestation_service=_AttestationService(),
         fleet_telemetry_service=None,

--- a/tests/unit/test_beagle_netbridge_regressions.py
+++ b/tests/unit/test_beagle_netbridge_regressions.py
@@ -14,6 +14,8 @@ CLIENT = NETBRIDGE_DIR / "beagle-netbridge-client"
 TRAY = NETBRIDGE_DIR / "beagle-netbridge-tray"
 TRAY_DESKTOP = NETBRIDGE_DIR / "beagle-netbridge-tray.desktop"
 TRAY_ICON = NETBRIDGE_DIR / "beagle-netbridge-tray.png"
+THINCLIENT_ADMIN = NETBRIDGE_DIR / "beagle-thinclient-admin"
+THINCLIENT_ADMIN_DESKTOP = NETBRIDGE_DIR / "beagle-thinclient-admin.desktop"
 AGENT_UNIT = NETBRIDGE_DIR / "beagle-netbridge-agent.service"
 CLIENT_UNIT = NETBRIDGE_DIR / "beagle-netbridge-client.service"
 FIRSTBOOT_TEMPLATE = ROOT / "beagle-host" / "templates" / "ubuntu-beagle" / "firstboot-provision.sh.tpl"
@@ -51,7 +53,7 @@ TC_ENABLE_HOOK = (
 
 
 def test_netbridge_assets_exist() -> None:
-    for path in (AGENT, CLIENT, AGENT_UNIT, CLIENT_UNIT):
+    for path in (AGENT, CLIENT, AGENT_UNIT, CLIENT_UNIT, THINCLIENT_ADMIN, THINCLIENT_ADMIN_DESKTOP):
         assert path.is_file(), f"missing {path}"
 
 
@@ -128,6 +130,8 @@ def test_agent_control_protocol_supports_manage_ops() -> None:
         "service_action",
         "usb_bind",
         "usb_unbind",
+        "thinclient_update",
+        "thinclient_power",
         "restart",
     ):
         assert f'op == "{op}"' in script
@@ -152,6 +156,10 @@ def test_agent_exposes_thinclient_inventory_and_stream_profiles() -> None:
         "def _list_video_devices()",
         "def _list_audio_capture_devices()",
         "def _list_network_interfaces()",
+        "def _thinclient_update_status()",
+        "def thinclient_update_action(self",
+        "def power_action(self",
+        "THINCLIENT_UPDATE_CLIENT",
         "STREAM_PRESETS",
         "lan-ultra",
         "survival",
@@ -249,6 +257,8 @@ def test_tray_control_client_and_queue_naming() -> None:
     control.status()
     control.set_stream_profile("balanced")
     control.service_action("stream", "restart")
+    control.thinclient_update("scan")
+    control.thinclient_power("reboot")
     control.usb_bind("1-2")
     control.usb_unbind("1-2")
     ops = [c["op"] for c in captured]
@@ -260,6 +270,8 @@ def test_tray_control_client_and_queue_naming() -> None:
         "status",
         "set_stream_profile",
         "service_action",
+        "thinclient_update",
+        "thinclient_power",
         "usb_bind",
         "usb_unbind",
     ]
@@ -267,7 +279,9 @@ def test_tray_control_client_and_queue_naming() -> None:
     assert captured[2]["id"] == "static-1-2-3-4-9100"
     assert captured[5]["profile"] == "balanced"
     assert captured[6]["service"] == "stream"
-    assert captured[7]["busid"] == "1-2"
+    assert captured[7]["action"] == "scan"
+    assert captured[8]["action"] == "reboot"
+    assert captured[9]["busid"] == "1-2"
 
 
 def test_tray_uses_system_tray_and_manager_actions() -> None:
@@ -315,6 +329,33 @@ def test_tray_uses_system_tray_and_manager_actions() -> None:
     assert "self._menu_open = True" in script
     assert "if self._menu_open:" in script
     assert "self._pending_data" in script
+    assert "Thinclient Verwaltung öffnen" in script
+    assert "def action_open_admin(self)" in script
+
+
+def test_thinclient_admin_app_exists_and_covers_full_management_center() -> None:
+    assert THINCLIENT_ADMIN.is_file()
+    import py_compile
+    py_compile.compile(str(THINCLIENT_ADMIN), doraise=True)
+    script = THINCLIENT_ADMIN.read_text(encoding="utf-8")
+    for snippet in (
+        "Updates & Neustart",
+        "Thinclient-Update installieren + Neustart",
+        "VM neu starten",
+        "Thinclient neu starten",
+        "Streamprofil setzen",
+        "USB, Audio, Webcam",
+        "LAN-Geraete",
+        "Diagnose",
+        "def thinclient_update_action(self",
+        "def vm_power_action(self",
+        "def thinclient_power_action(self",
+        "def set_selected_stream_profile(self",
+        "reboot_target_label",
+    ):
+        assert snippet in script
+    desktop = THINCLIENT_ADMIN_DESKTOP.read_text(encoding="utf-8")
+    assert "Exec=/usr/local/bin/beagle-thinclient-admin" in desktop
 
 
 def test_agent_service_grants_state_directory() -> None:
@@ -323,7 +364,7 @@ def test_agent_service_grants_state_directory() -> None:
     for unit in (AGENT_UNIT, TC_AGENT_UNIT):
         text = unit.read_text(encoding="utf-8")
         assert "StateDirectory=beagle/netbridge" in text
-        assert "ReadWritePaths=/var/lib/beagle-os" in text
+        assert "ReadWritePaths=/var/lib/beagle-os /var/cache/beagle-os /var/log/beagle-os" in text
 
 
 def test_firstboot_installs_tray_manager() -> None:
@@ -331,11 +372,18 @@ def test_firstboot_installs_tray_manager() -> None:
     # PyQt5 powers the tray; it is installed alongside the CUPS tooling.
     assert "python3-pyqt5" in script
     assert "BEAGLE_NETBRIDGE_TRAY_B64" in script
+    assert "BEAGLE_THINCLIENT_ADMIN_B64" in script
+    assert "BEAGLE_THINCLIENT_ADMIN_DESKTOP_B64" in script
     assert 'base64 -d > /usr/local/bin/beagle-netbridge-tray' in script
+    assert 'base64 -d > /usr/local/bin/beagle-thinclient-admin' in script
+    assert 'base64 -d > /usr/local/share/applications/beagle-thinclient-admin.desktop' in script
     assert "/usr/local/bin/beagle-netbridge-tray" in script
+    assert "/usr/local/bin/beagle-thinclient-admin" in script
     assert "/etc/sudoers.d/beagle-guest-updater" in script
     assert "beagle-guest-updater apply --reboot" in script
     assert "beagle-guest-updater desktop-profile-refresh --force" in script
+    assert "beagle-guest-updater reboot" in script
+    assert "beagle-guest-updater shutdown" in script
     # Autostart entry so the manager appears in the user's Plasma session.
     assert "/etc/xdg/autostart/beagle-netbridge-tray.desktop" in script
     assert "Exec=/usr/local/bin/beagle-netbridge-tray" in script

--- a/tests/unit/test_download_page_release_channel_regressions.py
+++ b/tests/unit/test_download_page_release_channel_regressions.py
@@ -17,6 +17,6 @@ def test_release_workflow_verifies_stable_and_prerelease_status_files() -> None:
 def test_publish_public_update_script_preserves_stable_when_prerelease_syncs() -> None:
     script = (ROOT / "scripts" / "publish-public-update-artifacts.sh").read_text(encoding="utf-8")
 
-    assert '"$REMOTE_TARGET/prereleases/$VERSION/"' in script
+    assert '"$REMOTE_TARGET_TRIMMED/prereleases/$VERSION/"' in script
     assert '"$PUBLISH_STAGE_ROOT/$STATUS_JSON_NAME"' in script
-    assert 'Published prerelease artifacts to $REMOTE_TARGET/prereleases/$VERSION and updated $STATUS_JSON_NAME' in script
+    assert 'Published prerelease artifacts to $REMOTE_TARGET_TRIMMED/prereleases/$VERSION and updated $STATUS_JSON_NAME' in script

--- a/tests/unit/test_endpoint_update_self_heal_regressions.py
+++ b/tests/unit/test_endpoint_update_self_heal_regressions.py
@@ -342,6 +342,17 @@ def test_desktop_guest_updater_supports_launcher_reboot_shutdown_actions(monkeyp
     assert shutdown_scheduled == [True]
 
 
+def test_desktop_guest_updater_exposes_direct_vm_power_cli() -> None:
+    script = GUEST_UPDATER.read_text(encoding="utf-8")
+    firstboot = UBUNTU_FIRSTBOOT.read_text(encoding="utf-8")
+
+    assert 'subparsers.add_parser("reboot")' in script
+    assert 'subparsers.add_parser("shutdown")' in script
+    assert 'reboot_target="vm"' in script
+    assert "beagle-guest-updater reboot" in firstboot
+    assert "beagle-guest-updater shutdown" in firstboot
+
+
 def test_endpoint_dispatch_supports_launcher_reboot_shutdown_with_fallback_services() -> None:
     script = ENDPOINT_DISPATCH.read_text(encoding="utf-8")
 

--- a/tests/unit/test_endpoint_update_self_heal_regressions.py
+++ b/tests/unit/test_endpoint_update_self_heal_regressions.py
@@ -19,6 +19,7 @@ UPDATE_CLIENT = ROOT / "beagle-os" / "overlay" / "usr" / "local" / "sbin" / "bea
 GUEST_UPDATER = ROOT / "beagle-host" / "bin" / "beagle-guest-updater"
 UBUNTU_FIRSTBOOT = ROOT / "beagle-host" / "templates" / "ubuntu-beagle" / "firstboot-provision.sh.tpl"
 HEALTHCHECK = ROOT / "beagle-os" / "overlay" / "usr" / "local" / "sbin" / "beagle-healthcheck"
+EGRESS_APPLY = ROOT / "beagle-os" / "overlay" / "usr" / "local" / "sbin" / "beagle-egress-apply"
 ENDPOINT_DISPATCH = ROOT / "beagle-os" / "overlay" / "usr" / "local" / "sbin" / "beagle-endpoint-dispatch"
 PREPARE_RUNTIME = ROOT / "thin-client-assistant" / "runtime" / "prepare-runtime.sh"
 SYSTEMD_UNITS = [
@@ -193,6 +194,26 @@ def test_healthcheck_marks_update_status_for_repair_reporting() -> None:
     assert "rollback_recommended" not in script  # owned by update-client status payload
     assert "beagle-stream-client target unreachable" in script
     assert "secure egress not ready" in script
+
+
+def test_healthcheck_uses_runtime_selected_stream_api_url() -> None:
+    script = HEALTHCHECK.read_text(encoding="utf-8")
+
+    assert "beagle_stream_client_targeting.sh" in script
+    assert "beagle_stream_client_api_url.sh" in script
+    assert "selected_beagle_stream_server_api_url" in script
+    assert 'resolved_beagle_stream_server_api_url="$(selected_beagle_stream_server_api_url' in script
+
+
+def test_egress_apply_can_mark_runtime_managed_wireguard_before_route_setup() -> None:
+    script = EGRESS_APPLY.read_text(encoding="utf-8")
+
+    assert script.index("write_status()") < script.index('write_status "managed-by-thinclient-runtime"')
+    assert '"$mode" != "direct"' in script
+    assert '"$egress_type" == "wireguard"' in script
+    assert '"$interface_name" == "wg-beagle"' in script
+    assert 'ip link show "$interface_name"' in script
+    assert 'write_status "pending-thinclient-runtime"' in script
 
 
 def test_healthcheck_probes_broker_allocation_without_logging_tokens() -> None:

--- a/tests/unit/test_goenterprise_zero_trust_acceptance.py
+++ b/tests/unit/test_goenterprise_zero_trust_acceptance.py
@@ -36,6 +36,7 @@ def _make_endpoint_http_surface(
         build_vm_profile=lambda _vm: {"stream_host": "srv1.beagle-os.com", "beagle_stream_client_port": "47984"},
         dequeue_vm_actions=lambda _node, _vmid: [],
         device_registry_service=registry,
+        device_log_service=None,
         mdm_policy_service=mdm,
         attestation_service=attestation,
         fleet_telemetry_service=None,

--- a/tests/unit/test_publish_public_update_artifacts_prerelease_regressions.py
+++ b/tests/unit/test_publish_public_update_artifacts_prerelease_regressions.py
@@ -14,8 +14,8 @@ def test_publish_public_update_artifacts_supports_prerelease_channel() -> None:
     assert 'prereleases/$VERSION' in script
     assert 'release_class' in script
     assert 'artifact_base_url' in script
-    assert '"$REMOTE_TARGET/prereleases/$VERSION/"' in script
-    assert '"$REMOTE_TARGET/$STATUS_JSON_NAME"' in script
+    assert '"$REMOTE_TARGET_TRIMMED/prereleases/$VERSION/"' in script
+    assert '"$REMOTE_TARGET_TRIMMED/$STATUS_JSON_NAME"' in script
 
 
 def test_publish_public_update_artifacts_keeps_stable_channel_separate() -> None:

--- a/tests/unit/test_request_handler_mixin_client_addr.py
+++ b/tests/unit/test_request_handler_mixin_client_addr.py
@@ -40,6 +40,9 @@ SPEC = importlib.util.spec_from_file_location("beagle_request_handler_mixin", MO
 module = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
 SPEC.loader.exec_module(module)
+module._svc_registry = service_registry_stub
+module.extract_bearer_token = service_registry_stub.extract_bearer_token
+module.load_endpoint_token = service_registry_stub.load_endpoint_token
 
 
 class DummyHandler(module.HandlerMixin):

--- a/tests/unit/test_sqlite_db.py
+++ b/tests/unit/test_sqlite_db.py
@@ -87,7 +87,7 @@ def test_repo_initial_schema_creates_expected_tables_and_indexes(tmp_path: Path)
         "SELECT name FROM sqlite_master WHERE type='index' ORDER BY name"
     ).fetchall()
 
-    assert applied == ["001_init.sql"]
+    assert applied == ["001_init.sql", "002_device_logs.sql"]
     assert {row[0] for row in table_rows} >= {
         "audit_events",
         "devices",

--- a/tests/unit/test_thin_client_live_build_regressions.py
+++ b/tests/unit/test_thin_client_live_build_regressions.py
@@ -367,11 +367,11 @@ def test_beaglestream_launcher_waits_for_manager_registration_before_stream_exec
     assert 'beagle-stream-client.register-wait-fail-open' in launcher_text
     assert 'beagle-stream-client.register-wait-timeout' in launcher_text
     assert 'pkill -TERM -f -- "--user-data-dir=${BEAGLE_STREAM_CLIENT_STARTUP_BROWSER_PROFILE}"' in launcher_text
-    assert 'ip route replace 0.0.0.0/1 dev "$iface"' in launcher_text
+    assert 'ensure_iface_route "0.0.0.0/1"' in launcher_text
     assert 'ip route delete default dev "$iface"' in launcher_text
-    assert 'ip route replace "$route" dev "$iface"' in launcher_text
+    assert 'ensure_iface_route "$route"' in launcher_text
     assert 'ip route replace "$endpoint_host" via "$default_gw" dev "$default_dev"' in launcher_text
-    assert 'sudo ip route replace "$route" dev "$iface" >/dev/null 2>&1 || true' in launcher_text
+    assert 'route_uses_dev "$route_spec" "$iface" && return 0' in launcher_text
     assert launcher_text.index('wait_for_beagle_stream_client_manager_registration || {') < launcher_text.index('beagle-stream-client.exec')
     assert 'beagle_stream_client_manager_url()' in manager_registration_text
     assert 'beagle_stream_enrollment_value control_plane' in manager_registration_text
@@ -409,7 +409,7 @@ def test_beaglestream_launcher_restores_wireguard_peer_without_truncating_base64
     assert 'WG_PEER_ALLOWED_IPS=%s' in prepare_text
     assert "print $3; exit" not in launcher_text
     assert 'beagle-stream-client.wg-routes-fallback' in launcher_text
-    assert 'sudo ip route replace "$route" dev "$iface"' in launcher_text
+    assert 'ensure_iface_route "$route"' in launcher_text
 
 
 def test_usbip_autobind_keeps_local_hid_devices_off_usbip_host() -> None:
@@ -508,6 +508,20 @@ def test_beaglestream_client_production_baseline_matches_live_smooth_profile() -
     assert 'PVE_THIN_CLIENT_BEAGLE_STREAM_CLIENT_DISPLAY_MODE="$BEAGLE_STREAM_CLIENT_DISPLAY_MODE"' in write_config_text
     assert 'PVE_THIN_CLIENT_BEAGLE_STREAM_CLIENT_AUTO_QUALITY="$BEAGLE_STREAM_CLIENT_AUTO_QUALITY"' in write_config_text
     assert 'PVE_THIN_CLIENT_BEAGLE_STREAM_CLIENT_DISABLE_VULKAN="$BEAGLE_STREAM_CLIENT_DISABLE_VULKAN"' in write_config_text
+
+
+def test_stream_launcher_does_not_rewrite_healthy_wireguard_routes_during_stream() -> None:
+    launcher_text = LAUNCH_BEAGLE_STREAM_CLIENT.read_text(encoding="utf-8")
+
+    assert "route_uses_dev()" in launcher_text
+    assert "endpoint_route_ok()" in launcher_text
+    assert "ensure_iface_route()" in launcher_text
+    assert 'routes_changed=0' in launcher_text
+    assert 'if [[ "$routes_changed" == "1" ]]; then' in launcher_text
+    assert 'route_uses_dev "0.0.0.0/1" "$iface"' in launcher_text
+    assert 'sudo ip route delete default dev "$iface"' in launcher_text
+    assert 'sudo ip route delete default dev "$iface" >/dev/null 2>&1 || true\n  IFS=' not in launcher_text
+    assert 'sudo ip route replace "$route" dev "$iface" >/dev/null 2>&1 || true' not in launcher_text
 
 
 def test_thin_client_build_can_stage_beagle_stream_client_wrapper() -> None:

--- a/thin-client-assistant/live-build/config/includes.chroot/etc/systemd/system/beagle-netbridge-agent.service
+++ b/thin-client-assistant/live-build/config/includes.chroot/etc/systemd/system/beagle-netbridge-agent.service
@@ -15,8 +15,9 @@ ProtectHome=yes
 PrivateTmp=yes
 # Persist manual devices added through the in-VM manager under /var/lib/beagle/netbridge.
 StateDirectory=beagle/netbridge
-# Stream quality presets are written into the launcher override state.
-ReadWritePaths=/var/lib/beagle-os
+# Stream presets and update actions write into Beagle state/cache and, on live
+# media, the persisted USB slot layout.
+ReadWritePaths=/var/lib/beagle-os /var/cache/beagle-os /var/log/beagle-os /run/live/medium /lib/live/mount/medium
 
 [Install]
 WantedBy=multi-user.target

--- a/thin-client-assistant/live-build/config/includes.chroot/usr/local/bin/beagle-netbridge-agent
+++ b/thin-client-assistant/live-build/config/includes.chroot/usr/local/bin/beagle-netbridge-agent
@@ -64,6 +64,14 @@ USBCTL = os.environ.get(
     "BEAGLE_NETBRIDGE_USBCTL",
     "/usr/local/lib/pve-thin-client/runtime/beagle-usbctl.sh",
 )
+THINCLIENT_UPDATE_CLIENT = os.environ.get(
+    "BEAGLE_NETBRIDGE_UPDATE_CLIENT",
+    "/usr/local/sbin/beagle-update-client",
+)
+THINCLIENT_UPDATE_STATUS_FILE = os.environ.get(
+    "BEAGLE_NETBRIDGE_UPDATE_STATUS_FILE",
+    "/var/lib/beagle-os/update/status.json",
+)
 
 STREAM_PROFILE_KEYS = {
     "resolution": "PVE_THIN_CLIENT_BEAGLE_STREAM_CLIENT_RESOLUTION",
@@ -205,6 +213,15 @@ def _json_cmd(args: list[str], timeout: int = 10) -> dict | None:
     except ValueError:
         return {"ok": False, "error": "invalid json response"}
     return payload if isinstance(payload, dict) else {"ok": False, "error": "invalid json response"}
+
+
+def _read_json_file(path: str) -> dict:
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, ValueError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
 
 
 def _list_network_interfaces() -> list[dict]:
@@ -374,10 +391,24 @@ def _thinclient_status() -> dict:
         "services": services,
         "network": {"interfaces": _list_network_interfaces()},
         "usb": usb,
+        "update": _thinclient_update_status(),
         "audio": {"capture_devices": _list_audio_capture_devices()},
         "video": {"devices": _list_video_devices()},
         "stream": _stream_profile_status(),
     }
+
+
+def _thinclient_update_status() -> dict:
+    status = _read_json_file(THINCLIENT_UPDATE_STATUS_FILE)
+    if not status and os.access(THINCLIENT_UPDATE_CLIENT, os.X_OK):
+        payload = _json_cmd([THINCLIENT_UPDATE_CLIENT, "status"], timeout=15)
+        if isinstance(payload, dict):
+            status = payload
+    status.setdefault("client", "thinclient-update-client")
+    status.setdefault("state", "unknown" if os.access(THINCLIENT_UPDATE_CLIENT, os.X_OK) else "missing")
+    status.setdefault("pending_reboot", False)
+    status.setdefault("reboot_target", "thinclient" if status.get("pending_reboot") else "")
+    return status
 
 
 # --------------------------------------------------------------------------- #
@@ -914,6 +945,57 @@ class Agent:
             return payload
         return {"ok": True, "action": action}
 
+    def thinclient_update_action(self, req: dict) -> dict:
+        action = str(req.get("action", "status")).strip()
+        if not os.access(THINCLIENT_UPDATE_CLIENT, os.X_OK):
+            return {"ok": False, "error": "thinclient update client not installed", "update": _thinclient_update_status()}
+        if action == "status":
+            return {"ok": True, "action": action, "update": _thinclient_update_status()}
+        commands = {
+            "scan": [THINCLIENT_UPDATE_CLIENT, "scan", "--force"],
+            "apply": [THINCLIENT_UPDATE_CLIENT, "apply", "--reboot"],
+            "rollback": [THINCLIENT_UPDATE_CLIENT, "rollback", "--reboot"],
+        }
+        command = commands.get(action)
+        if command is None:
+            return {"ok": False, "error": "unsupported thinclient update action"}
+        try:
+            result = _run(command, timeout=1800)
+        except (OSError, subprocess.SubprocessError) as exc:
+            return {"ok": False, "error": str(exc), "update": _thinclient_update_status()}
+        payload: dict = {}
+        if result.stdout.strip():
+            try:
+                parsed = json.loads(result.stdout)
+                payload = parsed if isinstance(parsed, dict) else {}
+            except ValueError:
+                payload = {}
+        if result.returncode != 0:
+            return {
+                "ok": False,
+                "error": result.stderr.strip() or result.stdout.strip() or f"update client exit {result.returncode}",
+                "update": _thinclient_update_status(),
+            }
+        return {"ok": True, "action": action, "update": payload or _thinclient_update_status()}
+
+    def power_action(self, req: dict) -> dict:
+        action = str(req.get("action", "")).strip()
+        commands = {
+            "reboot": ["systemctl", "reboot", "--no-block"],
+            "poweroff": ["systemctl", "poweroff", "--no-block"],
+        }
+        command = commands.get(action)
+        if command is None:
+            return {"ok": False, "error": "unsupported power action"}
+        try:
+            result = _run(command, timeout=8)
+        except (OSError, subprocess.SubprocessError) as exc:
+            return {"ok": False, "error": str(exc)}
+        if result.returncode != 0:
+            return {"ok": False, "error": result.stderr.strip() or result.stdout.strip()}
+        log(f"thinclient power action requested: {action}")
+        return {"ok": True, "target": "thinclient", "action": action}
+
     def _allocate_port(self) -> int:
         for port in PROXY_PORT_RANGE:
             if port not in self.used_ports:
@@ -1030,6 +1112,12 @@ class Agent:
             return self._catalog_payload(result)
         if op == "usb_unbind":
             result = self.usb_action(request, "unbind")
+            return self._catalog_payload(result)
+        if op == "thinclient_update":
+            result = self.thinclient_update_action(request)
+            return self._catalog_payload(result)
+        if op == "thinclient_power":
+            result = self.power_action(request)
             return self._catalog_payload(result)
         if op == "restart":
             return self.restart_agent()

--- a/thin-client-assistant/runtime/launch-beagle-stream-client.sh
+++ b/thin-client-assistant/runtime/launch-beagle-stream-client.sh
@@ -448,11 +448,13 @@ ensure_wg_interface() {
   local iface="wg-beagle"
   local wg_conf="/etc/wireguard/wg-beagle.conf"
   local allowed_ips endpoint endpoint_host
-  local default_route default_gw default_dev route_count route
+  local default_route default_gw default_dev route_count route routes_changed
 
   sudo test -f "$wg_conf" 2>/dev/null || return 0
   if ip link show "$iface" &>/dev/null; then
-    sudo ip link set up dev "$iface" >/dev/null 2>&1 || true
+    if ! ip link show "$iface" 2>/dev/null | grep -q '<[^>]*UP'; then
+      sudo ip link set up dev "$iface" >/dev/null 2>&1 || true
+    fi
   else
     beagle_log_event "beagle-stream-client.wg-interface-up" "iface=${iface} conf=${wg_conf}"
     sudo systemctl start "wg-quick@${iface}.service" >/dev/null 2>&1 || \
@@ -500,44 +502,82 @@ ensure_wg_interface() {
   default_route="$(ip route show default 2>/dev/null | awk -v iface="$iface" '$0 !~ (" dev " iface "( |$)") { print; exit }' || true)"
   default_gw="$(awk '/default/{for (i=1;i<=NF;i++) if ($i=="via") {print $(i+1); exit}}' <<<"$default_route")"
   default_dev="$(awk '/default/{for (i=1;i<=NF;i++) if ($i=="dev") {print $(i+1); exit}}' <<<"$default_route")"
-  if [[ -n "$endpoint_host" && -n "$default_dev" ]]; then
+  route_uses_dev() {
+    local route_spec="$1"
+    local route_dev="$2"
+    ip route show "$route_spec" 2>/dev/null | awk -v dev="$route_dev" '
+      $0 ~ (" dev " dev "([[:space:]]|$)") { found=1 }
+      END { exit(found ? 0 : 1) }
+    '
+  }
+  endpoint_route_ok() {
+    local route_line
+    [[ -n "$endpoint_host" && -n "$default_dev" ]] || return 0
+    route_line="$(ip route get "$endpoint_host" 2>/dev/null | head -n 1 || true)"
+    [[ "$route_line" == *" dev ${default_dev} "* || "$route_line" == *" dev ${default_dev}"* ]] || return 1
+    if [[ -n "$default_gw" ]]; then
+      [[ "$route_line" == *" via ${default_gw} "* ]]
+      return $?
+    fi
+    return 0
+  }
+  ensure_endpoint_route() {
+    [[ -n "$endpoint_host" && -n "$default_dev" ]] || return 0
+    endpoint_route_ok && return 0
     sudo ip route delete "$endpoint_host" dev "$iface" >/dev/null 2>&1 || true
     if [[ -n "$default_gw" ]]; then
       sudo ip route replace "$endpoint_host" via "$default_gw" dev "$default_dev" >/dev/null 2>&1 || true
     else
       sudo ip route replace "$endpoint_host" dev "$default_dev" >/dev/null 2>&1 || true
     fi
+    routes_changed=1
+  }
+  ensure_iface_route() {
+    local route_spec="$1"
+    route_uses_dev "$route_spec" "$iface" && return 0
+    sudo ip route replace "$route_spec" dev "$iface" >/dev/null 2>&1 || true
+    routes_changed=1
+  }
+  routes_changed=0
+  if [[ -n "$endpoint_host" && -n "$default_dev" ]]; then
+    ensure_endpoint_route
   fi
 
   route_count=0
-  sudo ip route delete default dev "$iface" >/dev/null 2>&1 || true
   IFS=',' read -r -a routes <<<"$allowed_ips"
   for route in "${routes[@]}"; do
     [[ -n "$route" ]] || continue
     case "$route" in
       0.0.0.0/0)
-        sudo ip route replace 0.0.0.0/1 dev "$iface" >/dev/null 2>&1 || true
-        sudo ip route replace 128.0.0.0/1 dev "$iface" >/dev/null 2>&1 || true
+        if ! route_uses_dev "0.0.0.0/1" "$iface" || ! route_uses_dev "128.0.0.0/1" "$iface"; then
+          sudo ip route delete default dev "$iface" >/dev/null 2>&1 || true
+          routes_changed=1
+        fi
+        ensure_iface_route "0.0.0.0/1"
+        ensure_iface_route "128.0.0.0/1"
         ;;
       ::/0)
-        sudo ip -6 route replace ::/1 dev "$iface" >/dev/null 2>&1 || true
-        sudo ip -6 route replace 8000::/1 dev "$iface" >/dev/null 2>&1 || true
+        if ! ip -6 route show ::/1 2>/dev/null | grep -q " dev ${iface}\\>"; then
+          sudo ip -6 route replace ::/1 dev "$iface" >/dev/null 2>&1 || true
+          routes_changed=1
+        fi
+        if ! ip -6 route show 8000::/1 2>/dev/null | grep -q " dev ${iface}\\>"; then
+          sudo ip -6 route replace 8000::/1 dev "$iface" >/dev/null 2>&1 || true
+          routes_changed=1
+        fi
         ;;
       *)
-        sudo ip route replace "$route" dev "$iface" >/dev/null 2>&1 || true
+        ensure_iface_route "$route"
         ;;
     esac
     route_count=$((route_count + 1))
   done
   if [[ -n "$endpoint_host" && -n "$default_dev" ]]; then
-    sudo ip route delete "$endpoint_host" dev "$iface" >/dev/null 2>&1 || true
-    if [[ -n "$default_gw" ]]; then
-      sudo ip route replace "$endpoint_host" via "$default_gw" dev "$default_dev" >/dev/null 2>&1 || true
-    else
-      sudo ip route replace "$endpoint_host" dev "$default_dev" >/dev/null 2>&1 || true
-    fi
+    ensure_endpoint_route
   fi
-  beagle_log_event "beagle-stream-client.wg-routes-fallback" "iface=${iface} routes=${route_count} endpoint=${endpoint_host:-none}"
+  if [[ "$routes_changed" == "1" ]]; then
+    beagle_log_event "beagle-stream-client.wg-routes-fallback" "iface=${iface} routes=${route_count} endpoint=${endpoint_host:-none}"
+  fi
 
   if ! ip link show "$iface" &>/dev/null; then
     beagle_log_event "beagle-stream-client.wg-interface-missing" "iface=${iface}"


### PR DESCRIPTION
## Summary

Adds a standalone Beagle Thinclient Verwaltung desktop app for the streamed VM. The tray remains a quick launcher and opens the full management center.

## What changed

- New PyQt5 management center covering dashboard, VM and thinclient updates, explicit reboot targets, stream profiles, services, USB/audio/webcam, LAN devices, network state, and diagnostics.
- NetBridge agent protocol now exposes thinclient update actions and thinclient power actions.
- VM guest updater now exposes direct `reboot` and `shutdown` CLI commands for the management center.
- Ubuntu-Beagle firstboot embeds and installs the new app and desktop launcher.
- Regression tests cover the app, provisioning bundle, protocol verbs, and VM power CLI.

## Validation

- `python3 -m py_compile beagle-host/netbridge/beagle-thinclient-admin beagle-host/netbridge/beagle-netbridge-tray beagle-host/netbridge/beagle-netbridge-agent thin-client-assistant/live-build/config/includes.chroot/usr/local/bin/beagle-netbridge-agent beagle-host/bin/beagle-guest-updater`
- `bash -n beagle-host/templates/ubuntu-beagle/firstboot-provision.sh.tpl`
- `python3 -m pytest -q tests/unit/test_beagle_netbridge_regressions.py tests/unit/test_endpoint_update_self_heal_regressions.py`
- `python3 -m pytest -q tests/unit/test_ubuntu_beagle_desktop_profiles.py tests/unit/test_ubuntu_beagle_autoinstall_iso.py tests/unit/test_ubuntu_beagle_firstboot_regressions.py`
- `beagle-host/netbridge/beagle-thinclient-admin --selftest`
