### PR TITLE
Fix thinclient stream, USB and telemetry recovery

### DIFF
--- a/.agents/backlog.md
+++ b/.agents/backlog.md
@@ -1,6 +1,6 @@
 # Backlog
 
-Stand: 2026-06-01
+Stand: 2026-08-02
 
 ## P0
 
@@ -17,8 +17,12 @@ Stand: 2026-06-01
 	- [x] Frischen-Boot Pairing-/TLS-Folgefehler gefunden und Repo-Fix plus Regressionstests ergaenzt.
 	- [x] Frischen-Boot Credential-/Token-Folgefehler gefunden: lokale BeagleStream-Client-Credentials fehlten und Manager-Token-Modus lief in PIN-Folgehandshake.
 	- [x] Lokales 8.3.18-Bootstreamfix-Payload gebaut und validiert (`filesystem.squashfs=668fed9d...`, Payload-SHA256 `18bb7bfc...`).
-	- [ ] Thinclient physisch power-cyclen oder wieder per SSH erreichen; Slot `b` mit dem korrigierten `668fed...` Image ersetzen.
+	- [x] Thinclient wieder per SSH erreicht und den laufenden VM100-Stream auf genau einen Client-Prozess stabilisiert.
+	- [x] VM-scoped USB-Konfiguration im Device-Sync nachgezogen und USB-/Mikrofon-Bridge live validiert.
 	- [ ] Neues Thinclient-Artefakt publizieren und frischen Live-USB-/Neuinstallationsstart ohne Hotpatch verifizieren.
+- [ ] `srv1` SATA-/Disk-Risiko operativ beheben: beide HGST RAID1-Mitglieder
+  kontrolliert ersetzen und Kabel/Controller pruefen; RAID-Rebuild und lange
+  SMART-Selbsttests dokumentieren.
 - [ ] Release-Versionierungslogik (stable/prerelease) gemaess `projectleader/todo.md` fertigstellen und absichern.
 	- [x] `scripts/resolve-release-version.sh`: Stable + Prerelease SemVer akzeptieren, `release_class` ausgeben, 4-part Versionsschema ablehnen.
 	- [x] `release.yml`: `release_class` fuer prerelease-spezifisches GitHub Release Verhalten (`--prerelease --latest=false`) verdrahten.

--- a/.agents/status.md
+++ b/.agents/status.md
@@ -26,6 +26,9 @@ Stand: 2026-07-30
 
 - Release-/Versionierungslogik bleibt hoch priorisiert (aus `projectleader/todo.md`).
 - Runtime-Gates brauchen weiter reale Host-Evidence.
+- `beagle-os.com` liefert seit 2026-06-28 ein abgelaufenes Zertifikat. Der
+  externe Webhost `212.227.63.45` ist mit dem vorhandenen SSH-Key nicht
+  zugaenglich; Public-Downloads bleiben bis zur Erneuerung blockiert.
 - Der aktuelle Hardware-Nachweis enthaelt Runtime-Deployments; ein frischer
   Image-Boot mit allen 2026-07-30-Fixes bleibt offen.
 - `AGENTS.md` ist aktuell in `.gitignore` enthalten; falls versioniert gewuenscht, muss bewusst entschieden werden, ob die Ignore-Regel angepasst oder `git add -f` genutzt wird.

--- a/.agents/status.md
+++ b/.agents/status.md
@@ -1,6 +1,6 @@
 # Autonomous Status
 
-Stand: 2026-06-24
+Stand: 2026-07-30
 
 ## Session Summary
 
@@ -17,19 +17,23 @@ Stand: 2026-06-24
 
 ## Aktueller Fokus
 
-- Beagle Thinclient Verwaltung aus dem NetBridge-Tray modernisieren und reparieren.
-- Hot-Test auf `srv1`/VM100 mit echtem NetBridge-Agenten, danach Commit/Push auf `main` und Stable-Release-Workflow.
-- `/goal`-Tool-Hinweis: Der alte usage-limited Goal-Eintrag konnte mit den verfuegbaren Tools nicht durch das neue Ziel ersetzt werden; der aktive Arbeitsstand wird deshalb hier und in `projectleader/state.md` festgehalten.
+- Thinclient-Stream-Selbstheilung fuer Gastnetzwerk, X11/KWallet und lokalen
+  Audio-Stack abschliessen.
+- Live validierten Fix als Branch/PR veroeffentlichen und danach in ein frisches
+  Thinclient-Artefakt uebernehmen.
 
 ## Offene Risiken
 
 - Release-/Versionierungslogik bleibt hoch priorisiert (aus `projectleader/todo.md`).
 - Runtime-Gates brauchen weiter reale Host-Evidence.
+- Der aktuelle Hardware-Nachweis enthaelt Runtime-Deployments; ein frischer
+  Image-Boot mit allen 2026-07-30-Fixes bleibt offen.
 - `AGENTS.md` ist aktuell in `.gitignore` enthalten; falls versioniert gewuenscht, muss bewusst entschieden werden, ob die Ignore-Regel angepasst oder `git add -f` genutzt wird.
 
 ## Naechster sinnvoller Schritt
 
-Thinclient-Verwaltungsfix final committen, auf `main` pushen und danach `release.yml` fuer den Stable-Release neu starten.
+Branch committen/pushen, PR-Checks abwarten und danach ein frisches
+Thinclient-Artefakt bauen und ohne Hotpatch booten.
 
 ## Session Update 2026-06-01 (Release Resolver Slice)
 
@@ -254,3 +258,24 @@ Thinclient-Verwaltungsfix final committen, auf `main` pushen und danach `release
 	- Echter Spectacle-Desktop-Screenshot erzeugt: `.tmp-thinclient-real-desktop.png`.
 	- Selftest weiter `agent_status: ok host=10.88.1.1`.
 - Release bleibt abgebrochen; kein neuer `release.yml`-Run gestartet.
+
+## Session Update 2026-07-30 (Stream Self-Healing)
+
+- Thinclient-Stopp bei Schritt 3 auf `192.168.178.30` reproduziert.
+- VM100 hatte nach einem fehlgeschlagenen DHCP-Renew keine IPv4-Adresse mehr;
+  ein neuer Gast-Network-Guardian repariert diesen Zustand automatisch.
+- Nach der Netzreparatur blockierten 221 alte Chrome-KWallet-Helper X11 und
+  verursachten Encoder-503. Provisionierung deaktiviert KWallet; der
+  Healthcheck prueft X11 und entfernt nur passende, alte Helper.
+- Der Thinclient-Audio-Watcher erbte seinen eigenen Initialisierungs-Lock in
+  PipeWire-Kinder. Lock-Deskriptoren sind jetzt getrennt und werden vor jedem
+  Hintergrundstart geschlossen.
+- Live auf `srv1`/VM100/Thinclient validiert:
+  - automatische IPv4-Wiederherstellung nach Fault Injection;
+  - aktive Netzwerk-, Stream- und Healthcheck-Guardians;
+  - X11 und `libx264` bereit, keine stale KWallet-Helper;
+  - sichtbarer VM100-Desktop, RTSP 1920x1080, Stereo-Audio, keine
+    Queue-Overflows und keine fehlgeschlagenen VM-Units.
+- Relevante Unit-/Integrationstests, Shell-Syntax und Diff-Check sind gruen.
+- Offen bleibt der frische Boot aus einem neu gebauten Image; der aktuelle
+  Hardwarelauf nutzt den live deployten Repository-Stand.

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist/
 *.pyc
 __pycache__/
 .tmp-beagle-*
+.tmp-thinclient-*
 SHA256SUMS
 node_modules/
 tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Fixed thin-client stream retries so detached BeagleStream clients are terminated and reaped before relaunch, preventing duplicate video/audio sessions after recovery.
+- Added VM-scoped USB tunnel configuration refresh through device sync, including legacy installer-token support, corrected microphone reverse-forward cleanup, and rate-limited VM microphone reconnect logs.
+- Hardened fleet telemetry JSONL ingestion against malformed records and concurrent pruning, and added SMART monitoring packages to host installer paths.
 - Fixed thin-client USB preset propagation so `PVE_THIN_CLIENT_PRESET_BEAGLE_MANAGER_TOKEN` survives installer generation and local preset installs instead of being dropped, preventing fresh USB recreates from losing required manager auth context.
 - Added stable/rolling Beagle update channels: server repo auto-update can now follow stable release tags or rolling GitHub main, and the Update Center exposes the channel switch beside installed/remote versions.
 - Added per-VM update policy switches in VM details for Updates active, automatic install behavior, and stable/rolling channel overrides.

--- a/beagle-host/services/endpoint_enrollment.py
+++ b/beagle-host/services/endpoint_enrollment.py
@@ -13,6 +13,19 @@ from typing import Any, Callable
 
 
 class EndpointEnrollmentService:
+    _RUNTIME_USB_CONFIG_KEYS = (
+        "usb_enabled",
+        "usb_tunnel_host",
+        "usb_tunnel_user",
+        "usb_tunnel_port",
+        "usb_camera_stream_port",
+        "usb_audio_input_port",
+        "usb_extra_reverse_forwards",
+        "usb_tunnel_attach_host",
+        "usb_tunnel_private_key",
+        "usb_tunnel_known_host",
+    )
+
     def __init__(
         self,
         *,
@@ -135,6 +148,26 @@ class EndpointEnrollmentService:
             "endpoint": endpoint_payload,
             "config": self._build_endpoint_config(profile, secret, endpoint_token, endpoint_id=endpoint_id),
         }
+
+    def build_runtime_usb_config(self, identity: dict[str, Any]) -> dict[str, Any]:
+        """Return current USB tunnel settings for an authenticated endpoint."""
+        vmid = int(identity.get("vmid", 0) or 0)
+        node = str(identity.get("node", "") or "").strip()
+        if vmid <= 0 or not node:
+            return {}
+
+        vm = self._find_vm(vmid)
+        if vm is None or str(getattr(vm, "node", "") or "").strip() != node:
+            return {}
+
+        endpoint_id = str(identity.get("endpoint_id") or identity.get("hostname") or f"{node}-{vmid}").strip()
+        config = self._build_endpoint_config(
+            self._build_profile(vm),
+            self._ensure_vm_secret(vm),
+            "",
+            endpoint_id=endpoint_id,
+        )
+        return {key: config[key] for key in self._RUNTIME_USB_CONFIG_KEYS if key in config}
 
     def _build_endpoint_config(
         self,

--- a/beagle-host/services/endpoint_http_surface.py
+++ b/beagle-host/services/endpoint_http_surface.py
@@ -58,6 +58,7 @@ class EndpointHttpSurfaceService:
         summarize_action_result: Callable[[dict[str, Any] | None], dict[str, Any]],
         utcnow: Callable[[], str],
         version: str,
+        build_endpoint_runtime_config: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
     ) -> None:
         self._build_vm_profile = build_vm_profile
         self._dequeue_vm_actions = dequeue_vm_actions
@@ -82,6 +83,7 @@ class EndpointHttpSurfaceService:
         self._summarize_action_result = summarize_action_result
         self._utcnow = utcnow
         self._version = str(version or "")
+        self._build_endpoint_runtime_config = build_endpoint_runtime_config
 
     @staticmethod
     def _json_response(status: HTTPStatus, payload: dict[str, Any]) -> dict[str, Any]:
@@ -462,6 +464,15 @@ class EndpointHttpSurfaceService:
             if not isinstance(stream_profile, dict):
                 stream_profile = {}
             update_state = self._device_update_state(device)
+            runtime_config: dict[str, Any] = {}
+            if callable(self._build_endpoint_runtime_config):
+                try:
+                    candidate = self._build_endpoint_runtime_config(identity)
+                    if isinstance(candidate, dict):
+                        runtime_config = candidate
+                except Exception:
+                    # Reporting and policy sync must survive transient secret-store errors.
+                    runtime_config = {}
 
             return self._json_response(
                 HTTPStatus.OK,
@@ -486,6 +497,7 @@ class EndpointHttpSurfaceService:
                             "target_sys_update": update_state["system"]["target"],
                         },
                         updates=update_state,
+                        runtime_config=runtime_config,
                         policy={
                             "policy_id": str(getattr(policy, "policy_id", "__default__") or "__default__"),
                             "name": str(getattr(policy, "name", "Default") or "Default"),

--- a/beagle-host/services/energy_service.py
+++ b/beagle-host/services/energy_service.py
@@ -114,8 +114,12 @@ class EnergyService:
 
     def get_samples(self, node_id: str, *, days: int = 30) -> list[EnergySample]:
         import datetime
+
+        now = datetime.datetime.fromisoformat(self._utcnow().replace("Z", "+00:00"))
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=datetime.timezone.utc)
         cutoff = (
-            datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=days)
+            now.astimezone(datetime.timezone.utc) - datetime.timedelta(days=days)
         ).strftime("%Y-%m-%d")
         samples = []
         for shard in sorted(self._dir.glob(f"{node_id}_*.jsonl")):

--- a/beagle-host/services/fleet_telemetry_service.py
+++ b/beagle-host/services/fleet_telemetry_service.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import json
 import math
+import os
+import threading
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Callable
@@ -75,6 +77,7 @@ class FleetTelemetryService:
         self._dir.mkdir(parents=True, exist_ok=True)
         self._utcnow = utcnow or self._default_utcnow
         self._migrate_vms_fn = migrate_vms_fn
+        self._telemetry_lock = threading.RLock()
         self._maintenance_store = JsonStateStore(
             self._dir / "maintenance_schedule.json",
             default_factory=list,
@@ -87,9 +90,10 @@ class FleetTelemetryService:
     def ingest(self, telemetry: DeviceTelemetry) -> None:
         """Store a telemetry record."""
         shard = self._dir / f"{telemetry.device_id}.jsonl"
-        with shard.open("a") as f:
-            f.write(json.dumps(asdict(telemetry)) + "\n")
-        self._prune(telemetry.device_id)
+        with self._telemetry_lock:
+            with shard.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(asdict(telemetry)) + "\n")
+            self._prune_locked(telemetry.device_id)
 
     def get_history(self, device_id: str, *, days: int = 30) -> list[DeviceTelemetry]:
         """Return telemetry history for a device (last N days)."""
@@ -100,12 +104,18 @@ class FleetTelemetryService:
         if not shard.exists():
             return []
         records = []
-        for line in shard.read_text().splitlines():
+        with self._telemetry_lock:
+            lines = shard.read_text(encoding="utf-8").splitlines()
+        for line in lines:
             if not line.strip():
                 continue
-            d = json.loads(line)
+            try:
+                d = json.loads(line)
+                record = DeviceTelemetry(**d)
+            except (json.JSONDecodeError, TypeError):
+                continue
             if d.get("timestamp", "") >= cutoff:
-                records.append(DeviceTelemetry(**d))
+                records.append(record)
         return records
 
     # ------------------------------------------------------------------
@@ -230,16 +240,39 @@ class FleetTelemetryService:
 
     def _prune(self, device_id: str) -> None:
         """Remove telemetry older than RETENTION_DAYS."""
+        with self._telemetry_lock:
+            self._prune_locked(device_id)
+
+    def _prune_locked(self, device_id: str) -> None:
         import datetime
         cutoff = (self._current_datetime() - datetime.timedelta(days=self.RETENTION_DAYS)).strftime("%Y-%m-%dT%H:%M:%S")
         shard = self._dir / f"{device_id}.jsonl"
         if not shard.exists():
             return
-        lines = [
-            line for line in shard.read_text().splitlines()
-            if line.strip() and json.loads(line).get("timestamp", "") >= cutoff
-        ]
-        shard.write_text("\n".join(lines) + ("\n" if lines else ""))
+        lines = []
+        changed = False
+        for line in shard.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                changed = True
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                changed = True
+                continue
+            if not isinstance(payload, dict) or payload.get("timestamp", "") < cutoff:
+                changed = True
+                continue
+            lines.append(line)
+        if not changed:
+            return
+
+        temp_path = shard.with_name(f".{shard.name}.{os.getpid()}.{threading.get_ident()}.tmp")
+        try:
+            temp_path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+            os.replace(temp_path, shard)
+        finally:
+            temp_path.unlink(missing_ok=True)
 
     @staticmethod
     def _default_utcnow() -> str:

--- a/beagle-host/services/service_registry.py
+++ b/beagle-host/services/service_registry.py
@@ -3811,6 +3811,7 @@ def endpoint_http_surface_service() -> EndpointHttpSurfaceService:
     if ENDPOINT_HTTP_SURFACE_SERVICE is None:
         ENDPOINT_HTTP_SURFACE_SERVICE = EndpointHttpSurfaceService(
             build_vm_profile=build_profile,
+            build_endpoint_runtime_config=endpoint_enrollment_service().build_runtime_usb_config,
             dequeue_vm_actions=dequeue_vm_actions,
             device_registry_service=device_registry_service(),
             device_log_service=device_log_service(),

--- a/beagle-host/templates/ubuntu-beagle/firstboot-provision.sh.tpl
+++ b/beagle-host/templates/ubuntu-beagle/firstboot-provision.sh.tpl
@@ -2078,6 +2078,12 @@ fi
 EOF
   chmod 0755 "/home/$GUEST_USER/.xprofile"
 
+  cat > "/home/$GUEST_USER/.config/kwalletrc" <<'EOF'
+[Wallet]
+Enabled=false
+First Use=false
+EOF
+
   cat > "/home/$GUEST_USER/.config/beagle-stream-server/beagle-stream-server.conf" <<EOF
 sunshine_name = ${GUEST_USER}-beagle-stream-server
 min_log_level = info
@@ -2265,12 +2271,16 @@ BEAGLE_STREAM_SERVER_PASSWORD="${BEAGLE_STREAM_SERVER_PASSWORD:-}"
 BEAGLE_STREAM_SERVER_PORT="${BEAGLE_STREAM_SERVER_PORT:-}"
 BEAGLE_STREAM_SERVER_HEALTHCHECK_GRACE_SEC="${BEAGLE_STREAM_SERVER_HEALTHCHECK_GRACE_SEC:-45}"
 BEAGLE_STREAM_SERVER_HEALTHCHECK_FAILURE_THRESHOLD="${BEAGLE_STREAM_SERVER_HEALTHCHECK_FAILURE_THRESHOLD:-4}"
+BEAGLE_STREAM_SERVER_KWALLET_MAX_AGE_SEC="${BEAGLE_STREAM_SERVER_KWALLET_MAX_AGE_SEC:-120}"
 GUEST_USER="${GUEST_USER:-beagle}"
 GUEST_UID="${GUEST_UID:-$(id -u "$GUEST_USER" 2>/dev/null || echo 1000)}"
 
 repair="${1:-}"
 if ! [[ "$BEAGLE_STREAM_SERVER_PORT" =~ ^[0-9]+$ ]]; then
   BEAGLE_STREAM_SERVER_PORT="50000"
+fi
+if ! [[ "$BEAGLE_STREAM_SERVER_KWALLET_MAX_AGE_SEC" =~ ^[1-9][0-9]*$ ]]; then
+  BEAGLE_STREAM_SERVER_KWALLET_MAX_AGE_SEC="120"
 fi
 api_port="$((BEAGLE_STREAM_SERVER_PORT + 1))"
 rtsp_port="$((BEAGLE_STREAM_SERVER_PORT + 21))"
@@ -2336,6 +2346,28 @@ service_is_warming_up() {
   [[ "$(service_uptime_sec)" -lt "$BEAGLE_STREAM_SERVER_HEALTHCHECK_GRACE_SEC" ]]
 }
 
+x11_session_ready() {
+  timeout 5 runuser -u "$GUEST_USER" -- \
+    env DISPLAY=:0 XAUTHORITY="/home/${GUEST_USER}/.Xauthority" \
+    xrandr --query >/dev/null 2>&1
+}
+
+reap_stale_chrome_wallet_queries() {
+  local pid elapsed comm args reaped=0
+
+  while read -r pid elapsed comm args; do
+    [[ "$comm" == "kwallet-query" ]] || continue
+    [[ "$elapsed" =~ ^[0-9]+$ ]] || continue
+    [[ "$elapsed" -ge "$BEAGLE_STREAM_SERVER_KWALLET_MAX_AGE_SEC" ]] || continue
+    [[ "$args" == *"--read-password Chrome Safe Storage"* ]] || continue
+    kill -TERM "$pid" >/dev/null 2>&1 || true
+    reaped="$((reaped + 1))"
+  done < <(ps -u "$GUEST_USER" -o pid=,etimes=,comm=,args= 2>/dev/null)
+
+  [[ "$reaped" -gt 0 ]] || return 1
+  logger -t beagle-stream-server-healthcheck "reaped ${reaped} stale Chrome KWallet helpers" >/dev/null 2>&1 || true
+}
+
 is_stream_ready() {
   curl -fsS --connect-timeout 3 --max-time 5 "http://127.0.0.1:${BEAGLE_STREAM_SERVER_PORT}/serverinfo" >/dev/null
 }
@@ -2393,6 +2425,23 @@ if ! beagle_stream_server_is_running && ! pgrep -x sunshine >/dev/null 2>&1; the
 fi
 
 if service_is_warming_up; then
+  exit 0
+fi
+
+if ! x11_session_ready; then
+  if reap_stale_chrome_wallet_queries; then
+    sleep 1
+  fi
+  if x11_session_ready; then
+    reset_readiness_failures
+    restart_stack
+    exit 0
+  fi
+  if record_readiness_failure; then
+    reset_readiness_failures
+    systemctl restart display-manager.service >/dev/null 2>&1 || true
+    restart_stack
+  fi
   exit 0
 fi
 
@@ -2546,6 +2595,143 @@ RestartSec=2
 
 [Install]
 WantedBy=multi-user.target
+EOF
+
+  cat > /usr/local/bin/beagle-guest-network-guardian <<'EOF'
+#!/usr/bin/env bash
+set -u
+
+state_dir="${BEAGLE_GUEST_NETWORK_GUARD_STATE_DIR:-/run/beagle-guest-network-guardian}"
+failure_file="${state_dir}/failures"
+failure_threshold="${BEAGLE_GUEST_NETWORK_FAILURE_THRESHOLD:-2}"
+reconfigure_wait_sec="${BEAGLE_GUEST_NETWORK_RECONFIGURE_WAIT_SEC:-15}"
+restart_wait_sec="${BEAGLE_GUEST_NETWORK_RESTART_WAIT_SEC:-20}"
+interface="${BEAGLE_GUEST_NETWORK_INTERFACE:-}"
+
+is_positive_integer() {
+  [[ "${1:-}" =~ ^[1-9][0-9]*$ ]]
+}
+
+select_interface() {
+  local candidate
+
+  if [[ -n "$interface" && -d "/sys/class/net/${interface}" ]]; then
+    return 0
+  fi
+
+  candidate="$(ip -4 route show default 2>/dev/null | awk 'NR == 1 {print $5}')"
+  if [[ -z "$candidate" ]]; then
+    candidate="$(networkctl list --no-legend --no-pager 2>/dev/null | awk '$3 == "ether" && $5 != "unmanaged" {print $2; exit}')"
+  fi
+  [[ -n "$candidate" && -d "/sys/class/net/${candidate}" ]] || return 1
+  interface="$candidate"
+}
+
+has_carrier() {
+  local carrier_file
+  carrier_file="${BEAGLE_GUEST_NETWORK_CARRIER_FILE:-/sys/class/net/${interface}/carrier}"
+  [[ -r "$carrier_file" ]] && [[ "$(cat "$carrier_file" 2>/dev/null || true)" == "1" ]]
+}
+
+has_ipv4() {
+  ip -4 -o addr show dev "$interface" scope global 2>/dev/null | grep -q .
+}
+
+wait_for_ipv4() {
+  local wait_sec="$1" attempt
+
+  for attempt in $(seq 1 "$wait_sec"); do
+    has_ipv4 && return 0
+    sleep 1
+  done
+  return 1
+}
+
+reset_failures() {
+  rm -f "$failure_file" >/dev/null 2>&1 || true
+}
+
+record_failure() {
+  local count
+
+  install -d -m 0755 "$state_dir" >/dev/null 2>&1 || true
+  count="$(cat "$failure_file" 2>/dev/null || echo 0)"
+  [[ "$count" =~ ^[0-9]+$ ]] || count=0
+  count="$((count + 1))"
+  printf '%s\n' "$count" >"$failure_file"
+  printf '%s\n' "$count"
+}
+
+log_event() {
+  logger -t beagle-guest-network-guardian "interface=${interface:-unknown} action=$1 ${2:-}" >/dev/null 2>&1 || true
+}
+
+is_positive_integer "$failure_threshold" || failure_threshold=2
+is_positive_integer "$reconfigure_wait_sec" || reconfigure_wait_sec=15
+is_positive_integer "$restart_wait_sec" || restart_wait_sec=20
+
+systemctl is-active --quiet systemd-networkd.service || exit 0
+select_interface || exit 0
+has_carrier || {
+  reset_failures
+  exit 0
+}
+has_ipv4 && {
+  reset_failures
+  exit 0
+}
+
+setup_failed=0
+networkctl status "$interface" --no-pager 2>/dev/null | grep -Eq 'State:.*\(failed\)' && setup_failed=1
+failure_count="$(record_failure)"
+if [[ "$setup_failed" != "1" && "$failure_count" -lt "$failure_threshold" ]]; then
+  exit 0
+fi
+
+log_event reconfigure "setup_failed=$setup_failed failures=$failure_count"
+networkctl reconfigure "$interface" >/dev/null 2>&1 || true
+if wait_for_ipv4 "$reconfigure_wait_sec"; then
+  reset_failures
+  log_event recovered "method=reconfigure"
+  exit 0
+fi
+
+log_event restart-networkd "reason=reconfigure-timeout"
+systemctl restart systemd-networkd.service >/dev/null 2>&1 || true
+if wait_for_ipv4 "$restart_wait_sec"; then
+  reset_failures
+  log_event recovered "method=restart-networkd"
+  exit 0
+fi
+
+log_event unavailable "reason=repair-exhausted"
+exit 0
+EOF
+  chmod 0755 /usr/local/bin/beagle-guest-network-guardian
+
+  cat > /etc/systemd/system/beagle-guest-network-guardian.service <<'EOF'
+[Unit]
+Description=Repair a stalled Beagle guest DHCP lease
+After=systemd-networkd.service
+Wants=systemd-networkd.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/beagle-guest-network-guardian
+EOF
+
+  cat > /etc/systemd/system/beagle-guest-network-guardian.timer <<'EOF'
+[Unit]
+Description=Check Beagle guest DHCP health periodically
+
+[Timer]
+OnBootSec=60s
+OnUnitActiveSec=30s
+RandomizedDelaySec=5s
+Unit=beagle-guest-network-guardian.service
+
+[Install]
+WantedBy=timers.target
 EOF
 
   configure_stream_port_guard() {
@@ -4100,6 +4286,7 @@ EOF
   systemctl enable --now beagle-stream-server.service >/dev/null 2>&1 || true
   systemctl enable --now beagle-stream-server-healthcheck.timer >/dev/null 2>&1 || true
   systemctl enable --now beagle-stream-server-guardian.service >/dev/null 2>&1 || true
+  systemctl enable --now beagle-guest-network-guardian.timer >/dev/null 2>&1 || true
   systemctl enable beagle-x11vnc.service >/dev/null 2>&1 || true
   if ! wait_for_beagle_stream_server_ready; then
     echo "WARN: Beagle Stream Server did not become ready during firstboot; continuing and leaving repair timer active" >&2

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -11,6 +11,7 @@ Produktivbetrieb. Pflicht-Lektuere fuer Operatoren vor Pilotbetrieb (R4).
 | [backup-restore.md](backup-restore.md) | VM-Backup, Restore, Single-File-Restore | Skelett |
 | [incident-response.md](incident-response.md) | Reaktion auf Stoerungen und Sicherheitsvorfaelle | Skelett |
 | [pilot.md](pilot.md) | Anleitung fuer Pilotkunden (Onboarding bis Tagesbetrieb) | Skelett |
+| [beaglestream-production-baseline.md](beaglestream-production-baseline.md) | Produktionsbaseline und Stream-Selbstheilung | Validiert |
 
 Status-Legende: **Skelett** = Struktur vorhanden, Befehle/Output fehlen ·
 **Entwurf** = erste Version mit echten Befehlen, ungetestet · **Validiert** =

--- a/docs/runbooks/beaglestream-production-baseline.md
+++ b/docs/runbooks/beaglestream-production-baseline.md
@@ -1,6 +1,6 @@
 # BeagleStream Production Baseline
 
-Stand: 2026-05-07
+Stand: 2026-07-30
 
 Dieser Runbook-Eintrag friert den auf VM100/srv1/lokalem Thinclient live validierten Zustand ein. Er ist der aktuelle produktionsnahe Standard fuer Kundenbetrieb, bis Hardware-Encoding und native Latenzmetriken nachgezogen sind.
 
@@ -12,7 +12,7 @@ Dieser Runbook-Eintrag friert den auf VM100/srv1/lokalem Thinclient live validie
 - Thinclient-Renderer: SDL/OpenGL, Vulkan deaktiviert.
 - Thinclient-Decode: `software` als getesteter stabiler Default.
 - Client-Flags: `--display-mode windowed`, `--no-frame-pacing`, `--no-vsync`, `--absolute-mouse`, `--no-hdr`, `--no-yuv444`.
-- Guest/Sunshine: `encoder = software`, `sw_preset = ultrafast`, `sw_tune = zerolatency`, `capture = kms`, `minimum_fps_target = 60`, `max_bitrate = 35000`.
+- Guest/BeagleStream: `encoder = software`, `sw_preset = ultrafast`, `sw_tune = zerolatency`, `capture = x11`, `minimum_fps_target = 60`, `max_bitrate = 35000`.
 - Guest/Xorg: `SWCursor` ist fuer den modesetting-Treiber aktiv, damit KMS den Mauszeiger auch ohne dedizierten Cursor-Plane im Videoframe sieht.
 - VM-Grafik: libvirt `virtio` video, nicht legacy VGA/Bochs.
 - Prozessprioritaet: QEMU, Sunshine und Thinclient-Client koennen mit `scripts/apply-beagle-stream-latency-tuning.sh` auf `Nice=-10` gebracht werden.
@@ -64,6 +64,55 @@ Wenn dieser Modus fehlschlaegt, ist der Serverpfad nicht automatisch kaputt:
 Dann ist der Thinclient nicht am Beagle-WireGuard sichtbar oder hat noch keinen
 Handshake aufgebaut. In diesem Fall Thinclient lokal oder per SSH pruefen und
 `wg-beagle` sowie den BeagleStream-Client neu starten.
+
+## Automatische Wiederherstellung
+
+Stream-VMs erhalten bei der Provisionierung folgende Schutzmechanismen:
+
+- `beagle-guest-network-guardian.timer` prueft alle 30 Sekunden, ob das
+  verwaltete Interface bei vorhandenem Carrier eine globale IPv4-Adresse hat.
+  Nach zwei fehlgeschlagenen Pruefungen wird zuerst `networkctl reconfigure`
+  ausgefuehrt und bei ausbleibender Erholung `systemd-networkd` neu gestartet.
+- `beagle-stream-server-healthcheck.timer` prueft neben API und Stream-Port auch
+  die X11-Sitzung mit `xrandr`. Alte `kwallet-query`-Prozesse werden nur dann
+  beendet, wenn sie mindestens 120 Sekunden alt sind und explizit nach
+  `Chrome Safe Storage` fragen. Bleibt X11 ueber den bestehenden
+  Fehlerschwellwert unerreichbar, werden Display-Manager und Stream-Dienst neu
+  gestartet.
+- KWallet ist im provisionierten Desktop deaktiviert, damit unbeaufsichtigte
+  Chromium-Prozesse keine Passwortdialoge oder blockierten Helper ansammeln.
+- Der Thinclient zeigt die Zielerreichbarkeit als eigenen Startschritt 4 und
+  startet den Stream bei einem serverseitigen Capture-/Encoder-503 kontrolliert
+  neu.
+- Der Thinclient-Audio-Watcher startet PipeWire, `pipewire-pulse` und
+  WirePlumber ohne geerbte Lock-Dateideskriptoren. Damit kann der Watcher den
+  Audio-Stack dauerhaft pruefen, ohne sich selbst zu blockieren.
+
+Schnellpruefung in der Stream-VM:
+
+```bash
+systemctl is-active \
+  beagle-guest-network-guardian.timer \
+  beagle-stream-server-healthcheck.timer \
+  beagle-stream-server-guardian.service \
+  beagle-stream-server.service
+ip -4 -o addr show scope global
+sudo -u <desktop-user> env \
+  DISPLAY=:0 XAUTHORITY=/home/<desktop-user>/.Xauthority \
+  xrandr --query
+pgrep -a -u <desktop-user> -x kwallet-query || true
+journalctl -u beagle-guest-network-guardian.service \
+  -u beagle-stream-server-healthcheck.service --since -15min
+```
+
+Erwartet werden aktive Timer/Guardians, eine globale Gast-IPv4-Adresse, ein
+erfolgreiches `xrandr` und keine dauerhaft laufenden Chrome-KWallet-Helper.
+
+Live validiert am 2026-07-30 mit `srv1`/VM100 und Thinclient
+`192.168.178.30`: erzwungener IPv4-Verlust wurde automatisch per
+`networkctl reconfigure` repariert; X11 und `libx264` erholten sich; der
+Thinclient baute RTSP, 1920x1080-Video und Stereo-Audio ohne Queue-Overflows
+auf.
 
 ## Bekannte Grenze
 

--- a/projectleader/state.md
+++ b/projectleader/state.md
@@ -62,6 +62,11 @@ LastHope/Diamond gates moving forward.
 - Live hotfixes on `srv1` must never remain only on the host.
 - Heavy artifact builds on live hosts can overload the machine; stop unintended
   refresh jobs before starting new release work.
+- Public host `beagle-os.com` (`212.227.63.45`) serves an expired Let's Encrypt
+  certificate (`notAfter=2026-06-28`). The repository deploys artifacts there
+  but does not manage that host's ACME lifecycle, and the available operator key
+  has no SSH access. Public downloads remain blocked until the external
+  certificate is renewed.
 - Local thinclient `192.168.178.30` is reachable again and currently streams
   VM100 successfully, but it is running the older live rootfs
   `filesystem.squashfs=11b66199...` with the current launcher/audio fixes

--- a/projectleader/state.md
+++ b/projectleader/state.md
@@ -1,6 +1,6 @@
 # Projectleader State
 
-Last updated: 2026-07-30
+Last updated: 2026-08-02
 
 ## Role
 
@@ -67,10 +67,15 @@ LastHope/Diamond gates moving forward.
   but does not manage that host's ACME lifecycle, and the available operator key
   has no SSH access. Public downloads remain blocked until the external
   certificate is renewed.
-- Local thinclient `192.168.178.30` is reachable again and currently streams
-  VM100 successfully, but it is running the older live rootfs
-  `filesystem.squashfs=11b66199...` with the current launcher/audio fixes
-  deployed at runtime.
+- Local thinclient `192.168.178.30` is reachable and currently streams VM100
+  successfully. The current launcher, runtime USB configuration and audio
+  bridge fixes are deployed at runtime; a fresh image validation is still
+  required.
+- `srv1` has repeated historical SATA NCQ timeouts on both RAID1 members.
+  RAID remains `[UU]` and SMART reports no pending or offline-uncorrectable
+  sectors, but the high reallocated-sector counters and 48-51 C temperatures
+  require scheduled disk/cable/controller inspection and likely disk
+  replacement. `smartd` is now enabled for continuous monitoring.
 - A corrected local thinclient payload exists, but the Streaming Gate remains
   open until a fresh image containing all 2026-07-30 fixes boots without
   runtime deployment and reaches a working VM desktop stream.
@@ -209,3 +214,27 @@ LastHope/Diamond gates moving forward.
   `git diff --check` passed.
 - Remaining release requirement: build and boot a fresh thinclient image from
   this commit; the current hardware proof includes runtime deployment.
+
+## Runtime Validation 2026-08-02 USB And Telemetry Recovery
+
+- Thinclient `192.168.178.30` had one orphaned BeagleStream process because the
+  launcher terminated only its shell wrapper. The launcher now terminates and
+  reaps stale client processes on retry and exit; live validation shows one
+  active desktop stream at 1920x1080 with stereo audio.
+- Existing installations retained their original VM-scoped installer token and
+  never refreshed USB tunnel settings. Device sync now returns only the current
+  VM-scoped USB configuration and updates tunnel files without rotating manager
+  or stream credentials. Legacy installer identities without endpoint metadata
+  remain supported through their authenticated node/VM scope.
+- The USB tunnel is active with reverse listeners for USB/IP, microphone audio
+  and camera transport. A physical SC420 USB microphone was selected
+  automatically as the unmuted default source after hotplug.
+- VM100 exposes `beagle_tc_microphone` as its default PipeWire source. An active
+  recording smoke test captured 983040 bytes with non-zero input signal and
+  transferred 496 frames with zero drops and zero reconnects.
+- A malformed telemetry JSONL record caused device sync HTTP 500 responses.
+  Telemetry reads now skip malformed records, ingestion is serialized, and
+  pruning replaces shards atomically. The live shard was repaired and repeated
+  device sync requests now return HTTP 200.
+- Thinclient, `srv1` and VM100 have no failed systemd units and no new error
+  journal entries after the fixes. RAID1 is healthy, and `smartd` is active.

--- a/projectleader/state.md
+++ b/projectleader/state.md
@@ -1,6 +1,6 @@
 # Projectleader State
 
-Last updated: 2026-06-24
+Last updated: 2026-07-30
 
 ## Role
 
@@ -62,13 +62,13 @@ LastHope/Diamond gates moving forward.
 - Live hotfixes on `srv1` must never remain only on the host.
 - Heavy artifact builds on live hosts can overload the machine; stop unintended
   refresh jobs before starting new release work.
-- Local thinclient `192.168.178.30` currently requires a physical power-cycle or
-  another way to restart the device: it pings, WireGuard handshakes through
-  `srv1` stay fresh, and TCP/22 is open, but sshd no longer sends a banner.
-  NetBridge/47100 is not reachable.
-- A corrected local thinclient payload exists, but the Streaming Gate is still
-  open until the device boots `filesystem.squashfs=668fed9d...` without
-  hotpatching and reaches a working VM desktop stream.
+- Local thinclient `192.168.178.30` is reachable again and currently streams
+  VM100 successfully, but it is running the older live rootfs
+  `filesystem.squashfs=11b66199...` with the current launcher/audio fixes
+  deployed at runtime.
+- A corrected local thinclient payload exists, but the Streaming Gate remains
+  open until a fresh image containing all 2026-07-30 fixes boots without
+  runtime deployment and reaches a working VM desktop stream.
 
 ## Operator Notes
 
@@ -165,3 +165,42 @@ LastHope/Diamond gates moving forward.
   controls for stream profile, LAN-device creation and USB attach/detach, with a
   larger real desktop window. The active VM100 desktop screenshot evidence is
   `.tmp-thinclient-real-desktop.png`; release remains cancelled.
+
+## Runtime Validation 2026-07-30 Stream Self-Healing
+
+- Reproduced the boot stop at step 3 on thinclient `192.168.178.30`.
+- Primary root cause in VM100:
+  - `systemd-networkd` failed a DHCPv4 renewal on `enp1s0`;
+  - VM100 lost `192.168.123.114`, while BeagleStream itself remained active;
+  - the launcher displayed step 3 while it was actually waiting for the stream
+    target.
+- Secondary root cause found after restoring the network:
+  - 221 stale `kwallet-query --read-password Chrome Safe Storage` helpers from
+    an unattended Chromium workload exhausted the X11 client limit;
+  - BeagleStream therefore returned HTTP 503 for video capture/encoding.
+- Third root cause found during the final E2E pass:
+  - PipeWire background processes inherited the audio initializer lock;
+  - the permanent watcher then blocked on that lock and never restored
+    WirePlumber, which stalled audio and the client's video event loop.
+- Repository fixes:
+  - guest network guardian with `networkctl reconfigure` and guarded
+    `systemd-networkd` restart fallback;
+  - X11-aware stream healthcheck, targeted stale Chrome-KWallet cleanup and
+    disabled KWallet for provisioned stream desktops;
+  - explicit thinclient stream-target step and controlled retry on capture 503;
+  - separate audio lock descriptor plus explicit lock closure for PipeWire and
+    WirePlumber background processes.
+- Live validation:
+  - forced IPv4 removal recovered automatically to `192.168.123.114`;
+  - network, healthcheck and stream guardians remained active;
+  - X11 stayed reachable with zero stale `kwallet-query` processes;
+  - BeagleStream selected `libx264`, opened a new X11 session and streamed the
+    actual VM100 desktop;
+  - thinclient RTSP reported 1920x1080 video and two-channel audio with zero
+    queue overflows after the audio repair;
+  - no failed units were present in VM100.
+- Local verification: `94 passed` for the consolidated provisioning, firstboot,
+  launcher, audio and endpoint suite; shell syntax checks and
+  `git diff --check` passed.
+- Remaining release requirement: build and boot a fresh thinclient image from
+  this commit; the current hardware proof includes runtime deployment.

--- a/projectleader/todo.md
+++ b/projectleader/todo.md
@@ -1,32 +1,15 @@
 # Projectleader Todo
 
-Last updated: 2026-07-30
+Last updated: 2026-08-02
 
 ## Immediate
 
 - [ ] Renew the expired TLS certificate for `beagle-os.com` on the external
   public webhost (`212.227.63.45`) and verify the public download status,
   thinclient payload and installer ISO without a TLS bypass.
-- [ ] Implement release channels for stable/prerelease:
-  - accept stable `x.y.z`;
-  - accept prerelease `x.y.z-alpha.N`, `x.y.z-beta.N`, `x.y.z-rc.N`;
-  - reject invalid four-part stable versions like `8.3.9.1` unless a deliberate
-    compatibility rule is added;
-  - expose a release-class output from `scripts/resolve-release-version.sh`.
-- [ ] Update release workflow so prereleases:
-  - are created with `gh release create --prerelease --latest=false`;
-  - do not run public stable artifact deployment;
-  - do not rewrite stable public `latest` files or `beagle-downloads-status.json`;
-  - still upload artifacts to the GitHub prerelease for testing.
-- [ ] Update `scripts/sync-release-version.py` so prerelease versions work with:
-  - root `VERSION`;
-  - WebUI cache-busting;
-  - Kiosk `package.json` and `package-lock.json`;
-  - browser extension manifest using numeric `version` plus full `version_name`.
-- [ ] Add unit/regression tests for stable vs alpha/beta/rc version resolution and
-  release workflow gating.
-- [ ] After release-system fix, build a new release from `f05e4b7` or newer and
-  validate it with a clean `srv1` installimage run.
+- [ ] Schedule maintenance for `srv1`: inspect SATA power/data paths and
+  controller logs, replace the two high-hour HGST RAID1 members in a controlled
+  sequence, and verify RAID rebuild plus extended SMART tests after each change.
 
 ## R1 Clean Install Gate
 
@@ -58,6 +41,12 @@ Last updated: 2026-07-30
   stream recovery on `srv1`.
 - [x] Fix the thinclient audio watcher lock inheritance and validate
   WirePlumber, RTSP, 1920x1080 video and stereo audio on hardware.
+- [x] Refresh VM-scoped USB tunnel configuration through device sync and support
+  legacy thinclient installer identities.
+- [x] Validate the USB/IP reverse listener and VM100 microphone bridge with an
+  active PipeWire recording (`dropped=0`, `reconnects=0`).
+- [x] Make telemetry JSONL recovery tolerant and restore recurring device sync
+  to HTTP 200.
 - [ ] Build and publish a fresh thin-client payload containing the boot,
   network/capture retry and audio-lock fixes.
 - [ ] Install and boot that fresh payload on the local thinclient, then confirm

--- a/projectleader/todo.md
+++ b/projectleader/todo.md
@@ -4,6 +4,9 @@ Last updated: 2026-07-30
 
 ## Immediate
 
+- [ ] Renew the expired TLS certificate for `beagle-os.com` on the external
+  public webhost (`212.227.63.45`) and verify the public download status,
+  thinclient payload and installer ISO without a TLS bypass.
 - [ ] Implement release channels for stable/prerelease:
   - accept stable `x.y.z`;
   - accept prerelease `x.y.z-alpha.N`, `x.y.z-beta.N`, `x.y.z-rc.N`;

--- a/projectleader/todo.md
+++ b/projectleader/todo.md
@@ -1,6 +1,6 @@
 # Projectleader Todo
 
-Last updated: 2026-05-31
+Last updated: 2026-07-30
 
 ## Immediate
 
@@ -51,9 +51,14 @@ Last updated: 2026-05-31
 - [x] Fix fresh-boot PairStatus/TLS readiness regression found during Slot-B boot.
 - [x] Fix fresh-boot missing BeagleStream client credentials and Manager token-mode pairing regression.
 - [x] Build a local fixed 8.3.18 thin-client payload for hardware recovery (`filesystem.squashfs=668fed9d...`, payload SHA256 `18bb7bfc...`).
-- [ ] Physically power-cycle or otherwise restart local thinclient, then install the corrected `668fed...` Slot-B image before the old pairing loop wedges SSH again.
-- [ ] Publish a fixed thin-client payload that contains the boot-to-stream hotfix.
-- [ ] Confirm streaming from a fresh thin-client payload without manual hotpatches.
+- [x] Repair VM100 DHCP/X11/KWallet failures and validate automatic network and
+  stream recovery on `srv1`.
+- [x] Fix the thinclient audio watcher lock inheritance and validate
+  WirePlumber, RTSP, 1920x1080 video and stereo audio on hardware.
+- [ ] Build and publish a fresh thin-client payload containing the boot,
+  network/capture retry and audio-lock fixes.
+- [ ] Install and boot that fresh payload on the local thinclient, then confirm
+  streaming without manual hotpatches.
 - [ ] Check WireGuard-required path, stream health events and absence of secrets in
   logs.
 

--- a/scripts/configure-beagle-stream-server-guest.sh
+++ b/scripts/configure-beagle-stream-server-guest.sh
@@ -224,7 +224,7 @@ require_tool() {
 parse_args() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --beagle-host|--beagle-host) BEAGLE_HOST="$2"; shift 2 ;; # --beagle-host kept for backwards compat
+      --beagle-host) BEAGLE_HOST="$2"; shift 2 ;;
       --vmid) VMID="$2"; shift 2 ;;
       --guest-user) GUEST_USER="$2"; shift 2 ;;
       --guest-password) GUEST_PASSWORD="$2"; shift 2 ;;
@@ -987,6 +987,12 @@ fi
 XPROFILE
 chmod 0755 "/home/\$GUEST_USER/.xprofile"
 
+cat > "/home/\$GUEST_USER/.config/kwalletrc" <<'KWALLETRC'
+[Wallet]
+Enabled=false
+First Use=false
+KWALLETRC
+
 cat > "/home/\$GUEST_USER/.config/beagle-stream-server/beagle-stream-server.conf" <<SUNCONF
 beagle_stream_server_name = ${GUEST_USER}-beagle-stream-server
 min_log_level = info
@@ -1179,12 +1185,16 @@ BEAGLE_STREAM_SERVER_PASSWORD="\${BEAGLE_STREAM_SERVER_PASSWORD:-}"
 BEAGLE_STREAM_SERVER_PORT="\${BEAGLE_STREAM_SERVER_PORT:-}"
 BEAGLE_STREAM_SERVER_HEALTHCHECK_GRACE_SEC="\${BEAGLE_STREAM_SERVER_HEALTHCHECK_GRACE_SEC:-45}"
 BEAGLE_STREAM_SERVER_HEALTHCHECK_FAILURE_THRESHOLD="\${BEAGLE_STREAM_SERVER_HEALTHCHECK_FAILURE_THRESHOLD:-4}"
+BEAGLE_STREAM_SERVER_KWALLET_MAX_AGE_SEC="\${BEAGLE_STREAM_SERVER_KWALLET_MAX_AGE_SEC:-120}"
 GUEST_USER="\${GUEST_USER:-beagle}"
 GUEST_UID="\${GUEST_UID:-\$(id -u "\$GUEST_USER" 2>/dev/null || echo 1000)}"
 
 repair="\${1:-}"
 if ! [[ "\$BEAGLE_STREAM_SERVER_PORT" =~ ^[0-9]+\$ ]]; then
   BEAGLE_STREAM_SERVER_PORT="50000"
+fi
+if ! [[ "\$BEAGLE_STREAM_SERVER_KWALLET_MAX_AGE_SEC" =~ ^[1-9][0-9]*\$ ]]; then
+  BEAGLE_STREAM_SERVER_KWALLET_MAX_AGE_SEC="120"
 fi
 api_port="\$((BEAGLE_STREAM_SERVER_PORT + 1))"
 rtsp_port="\$((BEAGLE_STREAM_SERVER_PORT + 21))"
@@ -1250,6 +1260,28 @@ service_is_warming_up() {
   [[ "\$(service_uptime_sec)" -lt "\$BEAGLE_STREAM_SERVER_HEALTHCHECK_GRACE_SEC" ]]
 }
 
+x11_session_ready() {
+  timeout 5 runuser -u "\$GUEST_USER" -- \
+    env DISPLAY=:0 XAUTHORITY="/home/\${GUEST_USER}/.Xauthority" \
+    xrandr --query >/dev/null 2>&1
+}
+
+reap_stale_chrome_wallet_queries() {
+  local pid elapsed comm args reaped=0
+
+  while read -r pid elapsed comm args; do
+    [[ "\$comm" == "kwallet-query" ]] || continue
+    [[ "\$elapsed" =~ ^[0-9]+\$ ]] || continue
+    [[ "\$elapsed" -ge "\$BEAGLE_STREAM_SERVER_KWALLET_MAX_AGE_SEC" ]] || continue
+    [[ "\$args" == *"--read-password Chrome Safe Storage"* ]] || continue
+    kill -TERM "\$pid" >/dev/null 2>&1 || true
+    reaped="\$((reaped + 1))"
+  done < <(ps -u "\$GUEST_USER" -o pid=,etimes=,comm=,args= 2>/dev/null)
+
+  [[ "\$reaped" -gt 0 ]] || return 1
+  logger -t beagle-stream-server-healthcheck "reaped \${reaped} stale Chrome KWallet helpers" >/dev/null 2>&1 || true
+}
+
 is_stream_ready() {
   curl -fsS --connect-timeout 3 --max-time 5 "http://127.0.0.1:\${BEAGLE_STREAM_SERVER_PORT}/serverinfo" >/dev/null
 }
@@ -1299,6 +1331,23 @@ if ! beagle_stream_server_is_running && ! pgrep -x sunshine >/dev/null 2>&1; the
 fi
 
 if service_is_warming_up; then
+  exit 0
+fi
+
+if ! x11_session_ready; then
+  if reap_stale_chrome_wallet_queries; then
+    sleep 1
+  fi
+  if x11_session_ready; then
+    reset_readiness_failures
+    restart_stack
+    exit 0
+  fi
+  if record_readiness_failure; then
+    reset_readiness_failures
+    systemctl restart display-manager.service >/dev/null 2>&1 || true
+    restart_stack
+  fi
   exit 0
 fi
 
@@ -1454,6 +1503,143 @@ RestartSec=2
 [Install]
 WantedBy=multi-user.target
 GUARDSVC
+
+cat > /usr/local/bin/beagle-guest-network-guardian <<'NETWORKGUARD'
+#!/usr/bin/env bash
+set -u
+
+state_dir="\${BEAGLE_GUEST_NETWORK_GUARD_STATE_DIR:-/run/beagle-guest-network-guardian}"
+failure_file="\${state_dir}/failures"
+failure_threshold="\${BEAGLE_GUEST_NETWORK_FAILURE_THRESHOLD:-2}"
+reconfigure_wait_sec="\${BEAGLE_GUEST_NETWORK_RECONFIGURE_WAIT_SEC:-15}"
+restart_wait_sec="\${BEAGLE_GUEST_NETWORK_RESTART_WAIT_SEC:-20}"
+interface="\${BEAGLE_GUEST_NETWORK_INTERFACE:-}"
+
+is_positive_integer() {
+  [[ "\${1:-}" =~ ^[1-9][0-9]*\$ ]]
+}
+
+select_interface() {
+  local candidate
+
+  if [[ -n "\$interface" && -d "/sys/class/net/\${interface}" ]]; then
+    return 0
+  fi
+
+  candidate="\$(ip -4 route show default 2>/dev/null | awk 'NR == 1 {print \$5}')"
+  if [[ -z "\$candidate" ]]; then
+    candidate="\$(networkctl list --no-legend --no-pager 2>/dev/null | awk '\$3 == "ether" && \$5 != "unmanaged" {print \$2; exit}')"
+  fi
+  [[ -n "\$candidate" && -d "/sys/class/net/\${candidate}" ]] || return 1
+  interface="\$candidate"
+}
+
+has_carrier() {
+  local carrier_file
+  carrier_file="\${BEAGLE_GUEST_NETWORK_CARRIER_FILE:-/sys/class/net/\${interface}/carrier}"
+  [[ -r "\$carrier_file" ]] && [[ "\$(cat "\$carrier_file" 2>/dev/null || true)" == "1" ]]
+}
+
+has_ipv4() {
+  ip -4 -o addr show dev "\$interface" scope global 2>/dev/null | grep -q .
+}
+
+wait_for_ipv4() {
+  local wait_sec="\$1" attempt
+
+  for attempt in \$(seq 1 "\$wait_sec"); do
+    has_ipv4 && return 0
+    sleep 1
+  done
+  return 1
+}
+
+reset_failures() {
+  rm -f "\$failure_file" >/dev/null 2>&1 || true
+}
+
+record_failure() {
+  local count
+
+  install -d -m 0755 "\$state_dir" >/dev/null 2>&1 || true
+  count="\$(cat "\$failure_file" 2>/dev/null || echo 0)"
+  [[ "\$count" =~ ^[0-9]+\$ ]] || count=0
+  count="\$((count + 1))"
+  printf '%s\n' "\$count" >"\$failure_file"
+  printf '%s\n' "\$count"
+}
+
+log_event() {
+  logger -t beagle-guest-network-guardian "interface=\${interface:-unknown} action=\$1 \${2:-}" >/dev/null 2>&1 || true
+}
+
+is_positive_integer "\$failure_threshold" || failure_threshold=2
+is_positive_integer "\$reconfigure_wait_sec" || reconfigure_wait_sec=15
+is_positive_integer "\$restart_wait_sec" || restart_wait_sec=20
+
+systemctl is-active --quiet systemd-networkd.service || exit 0
+select_interface || exit 0
+has_carrier || {
+  reset_failures
+  exit 0
+}
+has_ipv4 && {
+  reset_failures
+  exit 0
+}
+
+setup_failed=0
+networkctl status "\$interface" --no-pager 2>/dev/null | grep -Eq 'State:.*\(failed\)' && setup_failed=1
+failure_count="\$(record_failure)"
+if [[ "\$setup_failed" != "1" && "\$failure_count" -lt "\$failure_threshold" ]]; then
+  exit 0
+fi
+
+log_event reconfigure "setup_failed=\$setup_failed failures=\$failure_count"
+networkctl reconfigure "\$interface" >/dev/null 2>&1 || true
+if wait_for_ipv4 "\$reconfigure_wait_sec"; then
+  reset_failures
+  log_event recovered "method=reconfigure"
+  exit 0
+fi
+
+log_event restart-networkd "reason=reconfigure-timeout"
+systemctl restart systemd-networkd.service >/dev/null 2>&1 || true
+if wait_for_ipv4 "\$restart_wait_sec"; then
+  reset_failures
+  log_event recovered "method=restart-networkd"
+  exit 0
+fi
+
+log_event unavailable "reason=repair-exhausted"
+exit 0
+NETWORKGUARD
+chmod 0755 /usr/local/bin/beagle-guest-network-guardian
+
+cat > /etc/systemd/system/beagle-guest-network-guardian.service <<'NETWORKGUARDSVC'
+[Unit]
+Description=Repair a stalled Beagle guest DHCP lease
+After=systemd-networkd.service
+Wants=systemd-networkd.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/beagle-guest-network-guardian
+NETWORKGUARDSVC
+
+cat > /etc/systemd/system/beagle-guest-network-guardian.timer <<'NETWORKGUARDTIMER'
+[Unit]
+Description=Check Beagle guest DHCP health periodically
+
+[Timer]
+OnBootSec=60s
+OnUnitActiveSec=30s
+RandomizedDelaySec=5s
+Unit=beagle-guest-network-guardian.service
+
+[Install]
+WantedBy=timers.target
+NETWORKGUARDTIMER
 
 configure_stream_port_guard() {
   local stream_port="\${BEAGLE_STREAM_SERVER_PORT:-50000}"
@@ -1628,6 +1814,7 @@ activate_wireguard_stream_endpoint
 systemctl enable --now beagle-stream-server.service >/dev/null 2>&1 || true
 systemctl enable --now beagle-stream-server-healthcheck.timer >/dev/null 2>&1 || true
 systemctl enable --now beagle-stream-server-guardian.service >/dev/null 2>&1 || true
+systemctl enable --now beagle-guest-network-guardian.timer >/dev/null 2>&1 || true
 /usr/local/bin/beagle-stream-server-healthcheck >/dev/null 2>&1 || true
 
 # ── USB/IP auto-attach: forward thin-client USB devices into the VM ──────────

--- a/scripts/install-beagle-host.sh
+++ b/scripts/install-beagle-host.sh
@@ -209,7 +209,7 @@ ensure_dependencies() {
   fi
 
   apt-get update
-  DEBIAN_FRONTEND=noninteractive apt-get install -y rsync curl git
+  DEBIAN_FRONTEND=noninteractive apt-get install -y rsync curl git smartmontools
 }
 
 source_repo_url() {

--- a/scripts/lib/beagle-tc-mic-bridge
+++ b/scripts/lib/beagle-tc-mic-bridge
@@ -13,6 +13,8 @@ PREBUFFER_MSEC="${BEAGLE_TC_MIC_PREBUFFER_MSEC:-60}"
 MAX_BUFFER_MSEC="${BEAGLE_TC_MIC_MAX_BUFFER_MSEC:-200}"
 STATS_INTERVAL_SEC="${BEAGLE_TC_MIC_STATS_INTERVAL_SEC:-5}"
 RECONNECT_DELAY="${BEAGLE_TC_MIC_RECONNECT_DELAY:-1}"
+RETRY_LOG_EVERY="${BEAGLE_TC_MIC_RETRY_LOG_EVERY:-30}"
+[[ "$RETRY_LOG_EVERY" =~ ^[1-9][0-9]*$ ]] || RETRY_LOG_EVERY=30
 
 log() {
   printf '%s beagle-tc-mic-bridge: %s\n' "$(date -Is)" "$*" >&2
@@ -115,7 +117,12 @@ def emit_stats(prefix: str, fill_frames: int) -> None:
     f"silence={stats['silence_inserted']} dropped={stats['frames_dropped']} reconnects={stats['reconnects']}"
   )
 
-with socket.create_connection((host, port), timeout=10) as sock:
+try:
+  sock = socket.create_connection((host, port), timeout=10)
+except OSError:
+  raise SystemExit(75) from None
+
+with sock:
   try:
     sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
@@ -192,11 +199,16 @@ load_pipe_source
 normalize_source
 log "ready host=$BRIDGE_HOST port=$BRIDGE_PORT source=$SOURCE_NAME fifo=$FIFO_PATH rate=$RATE channels=$CHANNELS frame_msec=$FRAME_MSEC prebuffer_msec=$PREBUFFER_MSEC"
 
+failures=0
 while true; do
   if stream_once; then
+    failures=0
     log "stream ended; reconnecting"
   else
-    log "stream unavailable; retrying"
+    failures=$((failures + 1))
+    if [[ "$failures" -eq 1 || $((failures % RETRY_LOG_EVERY)) -eq 0 ]]; then
+      log "stream unavailable; retrying failures=$failures"
+    fi
   fi
   sleep "$RECONNECT_DELAY"
 done

--- a/server-installer/live-build/config/includes.chroot/usr/local/bin/beagle-server-installer
+++ b/server-installer/live-build/config/includes.chroot/usr/local/bin/beagle-server-installer
@@ -836,7 +836,7 @@ install_host_provider_packages() {
   fi
   chroot_run_with_retry \
     "install standalone host packages" \
-    "apt-get install -y locales sudo curl ca-certificates gnupg wget ifupdown2 openssh-server fail2ban unattended-upgrades apt-listchanges nftables git python3 rsync certbot python3-certbot-nginx nginx websockify linux-image-amd64 grub-pc grub-efi-amd64-bin efibootmgr dosfstools mdadm libvirt-daemon-system qemu-system-x86 qemu-utils"
+    "apt-get install -y locales sudo curl ca-certificates gnupg wget ifupdown2 openssh-server fail2ban unattended-upgrades apt-listchanges nftables git python3 rsync certbot python3-certbot-nginx nginx websockify smartmontools linux-image-amd64 grub-pc grub-efi-amd64-bin efibootmgr dosfstools mdadm libvirt-daemon-system qemu-system-x86 qemu-utils"
 }
 
 configure_target_raid() {

--- a/tests/integration/test_endpoint_boot_to_streaming.py
+++ b/tests/integration/test_endpoint_boot_to_streaming.py
@@ -443,6 +443,34 @@ class TestStreamingConfigFields:
         assert cfg["usb_tunnel_attach_host"] == "usb.internal"
         assert "srv1 ssh-ed25519" in cfg["usb_tunnel_known_host"]
 
+    def test_authenticated_endpoint_can_refresh_usb_runtime_config(self, enrollment_store, endpoint_store):
+        vm = _make_vm(vmid=404, node="srv1")
+        svc = _make_enrollment_service(enrollment_store, endpoint_store, vm_registry={404: vm})
+
+        config = svc.build_runtime_usb_config(
+            {"endpoint_id": "ep-404", "vmid": 404, "node": "srv1"}
+        )
+
+        assert config["usb_tunnel_host"] == "srv1"
+        assert config["usb_tunnel_user"] == "beagle-usb"
+        assert config["usb_tunnel_port"] == 2222
+        assert config["usb_tunnel_private_key"] == "MOCK_PRIVATE_KEY"
+        assert "beagle_manager_token" not in config
+        assert svc.build_runtime_usb_config(
+            {"endpoint_id": "ep-404", "vmid": 404, "node": "other-node"}
+        ) == {}
+
+    def test_legacy_installer_identity_can_refresh_usb_runtime_config(self, enrollment_store, endpoint_store):
+        vm = _make_vm(vmid=405, node="srv1")
+        svc = _make_enrollment_service(enrollment_store, endpoint_store, vm_registry={405: vm})
+
+        config = svc.build_runtime_usb_config(
+            {"endpoint_id": "", "hostname": "", "vmid": 405, "node": "srv1", "role": "thin-client-installer"}
+        )
+
+        assert config["usb_tunnel_port"] == 2222
+        assert config["usb_tunnel_private_key"] == "MOCK_PRIVATE_KEY"
+
     def test_config_has_update_fields(self, enrollment_store, endpoint_store):
         result = self._enroll(402, enrollment_store, endpoint_store)
         cfg = result["config"]

--- a/tests/unit/test_apply_enrollment_config.py
+++ b/tests/unit/test_apply_enrollment_config.py
@@ -9,7 +9,7 @@ RUNTIME_DIR = Path(__file__).resolve().parents[2] / "thin-client-assistant" / "r
 if str(RUNTIME_DIR) not in sys.path:
     sys.path.insert(0, str(RUNTIME_DIR))
 
-from apply_enrollment_config import apply_enrollment_config
+from apply_enrollment_config import apply_enrollment_config, apply_runtime_usb_config
 
 
 def test_apply_enrollment_config_persists_device_id(tmp_path: Path) -> None:
@@ -50,3 +50,44 @@ def test_apply_enrollment_config_persists_device_id(tmp_path: Path) -> None:
     ]
     assert oct(enrollment_conf.stat().st_mode & 0o777) == "0o640"
     assert oct(enrollment_conf.parent.stat().st_mode & 0o777) == "0o750"
+
+
+def test_apply_runtime_usb_config_preserves_existing_credentials(tmp_path: Path) -> None:
+    response = tmp_path / "response.json"
+    config = tmp_path / "thinclient.conf"
+    response.write_text(
+        json.dumps(
+            {
+                "runtime_config": {
+                    "usb_enabled": True,
+                    "usb_tunnel_host": "srv1.beagle-os.com",
+                    "usb_tunnel_user": "beagle-tunnel",
+                    "usb_tunnel_port": 43100,
+                    "usb_audio_input_port": 43200,
+                    "usb_tunnel_attach_host": "192.168.123.1",
+                    "usb_tunnel_private_key": "PRIVATE-KEY\n",
+                    "usb_tunnel_known_host": "srv1 ssh-ed25519 AAAA",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    config.write_text(
+        'PVE_THIN_CLIENT_BEAGLE_MANAGER_URL="https://manager.example"\n'
+        'PVE_THIN_CLIENT_BEAGLE_STREAM_CLIENT_HOST="keep-me"\n'
+        'PVE_THIN_CLIENT_BEAGLE_USB_TUNNEL_HOST=""\n',
+        encoding="utf-8",
+    )
+
+    assert apply_runtime_usb_config(response, config) is True
+    assert apply_runtime_usb_config(response, config) is False
+
+    config_text = config.read_text(encoding="utf-8")
+    assert 'PVE_THIN_CLIENT_BEAGLE_MANAGER_URL="https://manager.example"' in config_text
+    assert 'PVE_THIN_CLIENT_BEAGLE_STREAM_CLIENT_HOST="keep-me"' in config_text
+    assert 'PVE_THIN_CLIENT_BEAGLE_USB_TUNNEL_HOST="srv1.beagle-os.com"' in config_text
+    assert 'PVE_THIN_CLIENT_BEAGLE_USB_TUNNEL_PORT="43100"' in config_text
+    assert 'PVE_THIN_CLIENT_BEAGLE_AUDIO_INPUT_PORT="43200"' in config_text
+    assert (tmp_path / "usb-tunnel.key").read_text(encoding="utf-8") == "PRIVATE-KEY\n"
+    assert oct((tmp_path / "usb-tunnel.key").stat().st_mode & 0o777) == "0o600"
+    assert (tmp_path / "usb-tunnel-known_hosts").read_text(encoding="utf-8") == "srv1 ssh-ed25519 AAAA\n"

--- a/tests/unit/test_configure_beagle_stream_server_guest_regressions.py
+++ b/tests/unit/test_configure_beagle_stream_server_guest_regressions.py
@@ -1,8 +1,25 @@
+import os
 from pathlib import Path
+import subprocess
 
 
 ROOT_DIR = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT_DIR / "scripts" / "configure-beagle-stream-server-guest.sh"
+
+
+def _extract_heredoc(content: str, start: str, end: str) -> str:
+    return content.split(start, 1)[1].split(end, 1)[0]
+
+
+def _firstboot_network_guardian() -> str:
+    content = (
+        ROOT_DIR / "beagle-host" / "templates" / "ubuntu-beagle" / "firstboot-provision.sh.tpl"
+    ).read_text(encoding="utf-8")
+    return _extract_heredoc(
+        content,
+        "  cat > /usr/local/bin/beagle-guest-network-guardian <<'EOF'\n",
+        "\nEOF\n  chmod 0755 /usr/local/bin/beagle-guest-network-guardian",
+    )
 
 
 def test_configure_beagle_stream_server_guest_disables_display_idle_and_lockers() -> None:
@@ -19,6 +36,9 @@ def test_configure_beagle_stream_server_guest_disables_display_idle_and_lockers(
     assert 'xset -dpms >/dev/null 2>&1 || true' in content
     assert 'xset s off >/dev/null 2>&1 || true' in content
     assert 'xset s noblank >/dev/null 2>&1 || true' in content
+    assert 'cat > "/home/\\$GUEST_USER/.config/kwalletrc"' in content
+    assert "Enabled=false" in content
+    assert "First Use=false" in content
     assert '/home/\\$GUEST_USER/.local' in content
     assert '/home/\\$GUEST_USER/.local/state' in content
     assert '/home/\\$GUEST_USER/.local/state/wireplumber' in content
@@ -185,13 +205,23 @@ def test_configure_beagle_stream_server_guest_installs_uptime_guardian() -> None
     assert 'service_is_transitioning() {' in content
     assert 'BEAGLE_STREAM_SERVER_HEALTHCHECK_GRACE_SEC="\\${BEAGLE_STREAM_SERVER_HEALTHCHECK_GRACE_SEC:-45}"' in content
     assert 'BEAGLE_STREAM_SERVER_HEALTHCHECK_FAILURE_THRESHOLD="\\${BEAGLE_STREAM_SERVER_HEALTHCHECK_FAILURE_THRESHOLD:-4}"' in content
+    assert 'BEAGLE_STREAM_SERVER_KWALLET_MAX_AGE_SEC="\\${BEAGLE_STREAM_SERVER_KWALLET_MAX_AGE_SEC:-120}"' in content
     assert 'record_readiness_failure() {' in content
     assert 'service_is_warming_up() {' in content
+    assert 'x11_session_ready() {' in content
+    assert 'reap_stale_chrome_wallet_queries() {' in content
+    assert '[[ "\\$comm" == "kwallet-query" ]] || continue' in content
+    assert '[[ "\\$args" == *"--read-password Chrome Safe Storage"* ]] || continue' in content
+    assert 'if ! x11_session_ready; then' in content
+    assert 'systemctl restart display-manager.service' in content
     assert 'activating|reloading|deactivating) return 0 ;;' in content
     assert '"http://127.0.0.1:\\${BEAGLE_STREAM_SERVER_PORT}/serverinfo"' in content
     assert 'if is_stream_ready || is_api_ready; then' in content
     assert 'if beagle_stream_server_is_running; then' in content
-    assert content.index('if beagle_stream_server_is_running; then', content.index('if has_rtsp_port_conflict; then')) < content.index('if record_readiness_failure; then')
+    port_conflict_pos = content.index('if has_rtsp_port_conflict; then')
+    assert content.index('if beagle_stream_server_is_running; then', port_conflict_pos) < content.index(
+        'if record_readiness_failure; then', port_conflict_pos
+    )
     assert 'if record_readiness_failure; then' in content
     assert 'ensure_timer()' not in content
     assert 'BEAGLE_STREAM_SERVER_GUARD_RESTART_THRESHOLD="\\${BEAGLE_STREAM_SERVER_GUARD_RESTART_THRESHOLD:-4}"' in content
@@ -203,19 +233,143 @@ def test_configure_beagle_stream_server_guest_installs_uptime_guardian() -> None
     assert "systemctl enable --now beagle-stream-server-guardian.service" in content
 
 
+def test_stream_guest_provisioners_install_dhcp_self_healing() -> None:
+    configure_content = SCRIPT.read_text(encoding="utf-8")
+    firstboot_content = (
+        ROOT_DIR / "beagle-host" / "templates" / "ubuntu-beagle" / "firstboot-provision.sh.tpl"
+    ).read_text(encoding="utf-8")
+
+    for content in (configure_content, firstboot_content):
+        assert "beagle-guest-network-guardian" in content
+        assert "systemctl is-active --quiet systemd-networkd.service" in content
+        assert "networkctl reconfigure" in content
+        assert "systemctl restart systemd-networkd.service" in content
+        assert "BEAGLE_GUEST_NETWORK_FAILURE_THRESHOLD" in content
+        assert "OnUnitActiveSec=30s" in content
+        assert "systemctl enable --now beagle-guest-network-guardian.timer" in content
+
+
+def test_stream_guest_network_guardian_copies_stay_in_sync() -> None:
+    configure_content = SCRIPT.read_text(encoding="utf-8")
+    configure_guardian = _extract_heredoc(
+        configure_content,
+        "cat > /usr/local/bin/beagle-guest-network-guardian <<'NETWORKGUARD'\n",
+        "\nNETWORKGUARD\nchmod 0755 /usr/local/bin/beagle-guest-network-guardian",
+    ).replace("\\$", "$")
+
+    assert configure_guardian == _firstboot_network_guardian()
+
+
+def _write_mock_command(path: Path, content: str) -> None:
+    path.write_text("#!/usr/bin/env bash\nset -eu\n" + content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _run_network_guardian_repair(tmp_path: Path, recovery_method: str) -> list[str]:
+    guardian = tmp_path / "beagle-guest-network-guardian"
+    guardian.write_text(_firstboot_network_guardian(), encoding="utf-8")
+    guardian.chmod(0o755)
+
+    mock_bin = tmp_path / "bin"
+    mock_bin.mkdir()
+    calls = tmp_path / "calls"
+    ready = tmp_path / "ipv4-ready"
+    carrier = tmp_path / "carrier"
+    carrier.write_text("1\n", encoding="utf-8")
+
+    _write_mock_command(
+        mock_bin / "ip",
+        """
+printf 'ip %s\n' "$*" >>"$MOCK_CALLS"
+if [[ "$*" == "-4 -o addr show dev lo scope global" && -f "$MOCK_IPV4_READY" ]]; then
+  printf '1: lo inet 192.0.2.10/24 scope global lo\n'
+fi
+""",
+    )
+    _write_mock_command(
+        mock_bin / "networkctl",
+        """
+printf 'networkctl %s\n' "$*" >>"$MOCK_CALLS"
+case "${1:-}" in
+  status) printf 'State: degraded (failed)\n' ;;
+  reconfigure)
+    if [[ "$MOCK_RECOVERY_METHOD" == "reconfigure" ]]; then
+      touch "$MOCK_IPV4_READY"
+    fi
+    ;;
+esac
+""",
+    )
+    _write_mock_command(
+        mock_bin / "systemctl",
+        """
+printf 'systemctl %s\n' "$*" >>"$MOCK_CALLS"
+if [[ "${1:-}" == "restart" && "$MOCK_RECOVERY_METHOD" == "restart" ]]; then
+  touch "$MOCK_IPV4_READY"
+fi
+exit 0
+""",
+    )
+    _write_mock_command(
+        mock_bin / "logger",
+        """printf 'logger %s\n' "$*" >>"$MOCK_CALLS"\n""",
+    )
+
+    env = {
+        **os.environ,
+        "PATH": f"{mock_bin}:{os.environ['PATH']}",
+        "MOCK_CALLS": str(calls),
+        "MOCK_IPV4_READY": str(ready),
+        "MOCK_RECOVERY_METHOD": recovery_method,
+        "BEAGLE_GUEST_NETWORK_INTERFACE": "lo",
+        "BEAGLE_GUEST_NETWORK_CARRIER_FILE": str(carrier),
+        "BEAGLE_GUEST_NETWORK_GUARD_STATE_DIR": str(tmp_path / "state"),
+        "BEAGLE_GUEST_NETWORK_RECONFIGURE_WAIT_SEC": "1",
+        "BEAGLE_GUEST_NETWORK_RESTART_WAIT_SEC": "1",
+    }
+    subprocess.run([str(guardian)], check=True, env=env)
+    return calls.read_text(encoding="utf-8").splitlines()
+
+
+def test_stream_guest_network_guardian_repairs_failed_link_with_reconfigure(tmp_path: Path) -> None:
+    calls = _run_network_guardian_repair(tmp_path, "reconfigure")
+
+    assert "networkctl reconfigure lo" in calls
+    assert "systemctl restart systemd-networkd.service" not in calls
+    assert any("action=recovered method=reconfigure" in call for call in calls)
+
+
+def test_stream_guest_network_guardian_restarts_networkd_after_reconfigure_timeout(tmp_path: Path) -> None:
+    calls = _run_network_guardian_repair(tmp_path, "restart")
+
+    assert "networkctl reconfigure lo" in calls
+    assert "systemctl restart systemd-networkd.service" in calls
+    assert any("action=recovered method=restart-networkd" in call for call in calls)
+
+
 def test_firstboot_stream_server_healthcheck_avoids_startup_restart_loop() -> None:
     content = (ROOT_DIR / "beagle-host" / "templates" / "ubuntu-beagle" / "firstboot-provision.sh.tpl").read_text(encoding="utf-8")
 
     assert 'service_is_transitioning() {' in content
     assert 'BEAGLE_STREAM_SERVER_HEALTHCHECK_GRACE_SEC="${BEAGLE_STREAM_SERVER_HEALTHCHECK_GRACE_SEC:-45}"' in content
     assert 'BEAGLE_STREAM_SERVER_HEALTHCHECK_FAILURE_THRESHOLD="${BEAGLE_STREAM_SERVER_HEALTHCHECK_FAILURE_THRESHOLD:-4}"' in content
+    assert 'BEAGLE_STREAM_SERVER_KWALLET_MAX_AGE_SEC="${BEAGLE_STREAM_SERVER_KWALLET_MAX_AGE_SEC:-120}"' in content
     assert 'record_readiness_failure() {' in content
     assert 'service_is_warming_up() {' in content
+    assert 'x11_session_ready() {' in content
+    assert 'reap_stale_chrome_wallet_queries() {' in content
+    assert '[[ "$comm" == "kwallet-query" ]] || continue' in content
+    assert '[[ "$args" == *"--read-password Chrome Safe Storage"* ]] || continue' in content
+    assert 'if ! x11_session_ready; then' in content
+    assert 'systemctl restart display-manager.service' in content
     assert 'activating|reloading|deactivating) return 0 ;;' in content
     assert '"http://127.0.0.1:${BEAGLE_STREAM_SERVER_PORT}/serverinfo"' in content
     assert 'if is_stream_ready || is_api_ready; then' in content
     assert 'if beagle_stream_server_is_running; then' in content
-    assert content.index('if beagle_stream_server_is_running; then', content.index('if has_rtsp_port_conflict; then')) < content.index('if record_readiness_failure; then')
+    port_conflict_pos = content.index('if has_rtsp_port_conflict; then')
+    assert content.index('if beagle_stream_server_is_running; then', port_conflict_pos) < content.index(
+        'if record_readiness_failure; then', port_conflict_pos
+    )
     assert 'if record_readiness_failure; then' in content
     assert "cat > /usr/local/bin/beagle-stream-server-guardian <<'EOF'" in content
     assert 'BEAGLE_STREAM_SERVER_GUARD_RESTART_THRESHOLD="${BEAGLE_STREAM_SERVER_GUARD_RESTART_THRESHOLD:-4}"' in content

--- a/tests/unit/test_endpoint_http_surface.py
+++ b/tests/unit/test_endpoint_http_surface.py
@@ -30,6 +30,7 @@ def _service(
     store_action_result=None,
     usb_key_sync_hook=None,
     device_log_service=None,
+    runtime_config_hook=None,
 ) -> EndpointHttpSurfaceService:
     vm = _Vm(100, "beagle-0")
     profiles = {
@@ -251,6 +252,7 @@ def _service(
         summarize_action_result=lambda payload: payload or {},
         utcnow=lambda: "2026-04-22T00:00:00Z",
         version="test",
+        build_endpoint_runtime_config=runtime_config_hook,
     )
 
 
@@ -641,6 +643,30 @@ def test_device_sync_route_returns_persisted_offline_update_targets() -> None:
     }
     assert response["payload"]["commands"]["install_update"] is True
     assert response["payload"]["commands"]["install_sys_update"] is True
+
+
+def test_device_sync_route_returns_current_runtime_config() -> None:
+    service = _service(
+        runtime_config_hook=lambda identity: {
+            "usb_tunnel_host": "srv1.beagle-os.com",
+            "usb_tunnel_port": 43100,
+            "endpoint": identity["endpoint_id"],
+        }
+    )
+
+    response = service.route_post(
+        "/api/v1/endpoints/device/sync",
+        endpoint_identity={"endpoint_id": "endpoint-a", "vmid": 100, "node": "beagle-0", "hostname": "thin-01"},
+        query={},
+        json_payload={"hardware": {"cpu_model": "Intel"}},
+    )
+
+    assert int(response["status"]) == 200
+    assert response["payload"]["runtime_config"] == {
+        "usb_tunnel_host": "srv1.beagle-os.com",
+        "usb_tunnel_port": 43100,
+        "endpoint": "endpoint-a",
+    }
 
 
 def test_device_sync_route_ingests_metrics_and_emits_alert_counts() -> None:

--- a/tests/unit/test_fleet_telemetry.py
+++ b/tests/unit/test_fleet_telemetry.py
@@ -53,6 +53,19 @@ def test_get_history_returns_sample(tmp_path):
     assert history[0].cpu_temp_c == 55.0
 
 
+def test_ingest_repairs_malformed_shard_line(tmp_path):
+    svc = make_svc(tmp_path)
+    svc.ingest(normal_telemetry("dev-001", "2026-04-25T11:00:00Z"))
+    shard = tmp_path / "dev-001.jsonl"
+    with shard.open("a", encoding="utf-8") as handle:
+        handle.write('{"timestamp":"truncated"\n')
+
+    svc.ingest(normal_telemetry("dev-001"))
+
+    assert len(svc.get_history("dev-001", days=1)) == 2
+    assert all(line.endswith("}") for line in shard.read_text(encoding="utf-8").splitlines())
+
+
 def test_no_anomaly_for_healthy_device(tmp_path):
     svc = make_svc(tmp_path)
     for i in range(10):

--- a/tests/unit/test_install_beagle_host_services_regressions.py
+++ b/tests/unit/test_install_beagle_host_services_regressions.py
@@ -6,6 +6,17 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts" / "install-beagle-host-services.sh"
 HOST_INSTALL_SCRIPT = ROOT / "scripts" / "install-beagle-host.sh"
+SERVER_INSTALLER = (
+    ROOT
+    / "server-installer"
+    / "live-build"
+    / "config"
+    / "includes.chroot"
+    / "usr"
+    / "local"
+    / "bin"
+    / "beagle-server-installer"
+)
 
 
 def test_legacy_host_runtime_dir_uses_underscore_alias() -> None:
@@ -83,6 +94,11 @@ def test_host_install_initializes_opt_beagle_as_git_checkout_when_source_is_git(
     assert 'git -C "$INSTALL_DIR" reset --hard "$target"' in script
     assert 'git -C "$INSTALL_DIR" config --local beagle.runtime true' in script
     assert "ensure_install_dir_git_checkout" in script.split('python3 "$INSTALL_DIR/scripts/sync-web-ui-version.py"', 1)[0]
+
+
+def test_server_install_paths_include_smart_monitoring() -> None:
+    assert "smartmontools" in HOST_INSTALL_SCRIPT.read_text(encoding="utf-8")
+    assert "smartmontools" in SERVER_INSTALLER.read_text(encoding="utf-8")
 
 
 def test_firewall_baseline_is_enabled_by_default_without_libvirt_dependency() -> None:

--- a/tests/unit/test_tc_mic_bridge_jitter_regressions.py
+++ b/tests/unit/test_tc_mic_bridge_jitter_regressions.py
@@ -44,3 +44,12 @@ def test_tc_mic_bridge_service_has_cpu_safety_limit() -> None:
 
     assert "Nice=5" in service
     assert "CPUQuota=25%" in service
+
+
+def test_tc_mic_bridge_rate_limits_unavailable_stream_logs() -> None:
+    script = (ROOT / "scripts" / "lib" / "beagle-tc-mic-bridge").read_text(encoding="utf-8")
+
+    assert 'BEAGLE_TC_MIC_RETRY_LOG_EVERY:-30' in script
+    assert 'raise SystemExit(75) from None' in script
+    assert 'failures=$((failures + 1))' in script
+    assert '$((failures % RETRY_LOG_EVERY))' in script

--- a/tests/unit/test_thin_client_audio_init_sink_selection.py
+++ b/tests/unit/test_thin_client_audio_init_sink_selection.py
@@ -84,3 +84,12 @@ def test_select_sink_falls_back_to_usb_when_only_usb_exists(tmp_path: Path) -> N
         "56 alsa_output.usb-SC420_USB_Microphone_SC420_USB_Microphone_20220325-00.analog-stereo PipeWire s16le 2ch 48000Hz SUSPENDED\n",
     )
     assert selected == "alsa_output.usb-SC420_USB_Microphone_SC420_USB_Microphone_20220325-00.analog-stereo"
+
+
+def test_audio_background_processes_do_not_inherit_guard_locks() -> None:
+    content = AUDIO_INIT.read_text(encoding="utf-8")
+
+    assert 'nohup "$@" 8>&- 9>&-' in content
+    assert '8>&- 9>&- >>"$log_file"' in content
+    assert 'flock -w "$lock_wait" 8' in content
+    assert '} 8>"$lock_file"' in content

--- a/tests/unit/test_thin_client_live_build_regressions.py
+++ b/tests/unit/test_thin_client_live_build_regressions.py
@@ -413,6 +413,15 @@ def test_beaglestream_launcher_waits_for_manager_registration_before_stream_exec
     assert 'awk -F= \'$1 == "control_plane"' in manager_registration_text
 
 
+def test_direct_stream_reachability_has_its_own_startup_step() -> None:
+    launcher_text = LAUNCH_BEAGLE_STREAM_CLIENT.read_text(encoding="utf-8")
+
+    status_step = 'beagle_stream_startup_status_step "4" "Stream-Ziel pruefen"'
+    wait_call = "wait_for_stream_target || {"
+    assert status_step in launcher_text
+    assert launcher_text.index(status_step) < launcher_text.index(wait_call)
+
+
 def test_beaglestream_startup_indicator_has_crash_fallback_and_log() -> None:
     launcher_text = LAUNCH_BEAGLE_STREAM_CLIENT.read_text(encoding="utf-8")
 
@@ -424,6 +433,15 @@ def test_beaglestream_startup_indicator_has_crash_fallback_and_log() -> None:
     assert 'beagle_stream_startup_status_xmessage "$title"' in launcher_text
     assert '>>"$BEAGLE_STREAM_CLIENT_STARTUP_UI_LOG_FILE" 2>&1' in launcher_text
     assert '--disable-gpu' in launcher_text
+
+
+def test_beaglestream_launcher_retries_server_capture_failures() -> None:
+    launcher_text = LAUNCH_BEAGLE_STREAM_CLIENT.read_text(encoding="utf-8")
+
+    assert "Failed to initialize video capture/encoding" in launcher_text
+    assert "Host returned error:.*Error 503" in launcher_text
+    assert "reason=server-capture-unavailable" in launcher_text
+    assert 'kill -TERM "$stream_pid"' in launcher_text
 
 
 def test_prepare_host_downloads_rebuilds_payload_after_public_mirror_fallback() -> None:

--- a/tests/unit/test_thin_client_live_build_regressions.py
+++ b/tests/unit/test_thin_client_live_build_regressions.py
@@ -444,6 +444,16 @@ def test_beaglestream_launcher_retries_server_capture_failures() -> None:
     assert 'kill -TERM "$stream_pid"' in launcher_text
 
 
+def test_beaglestream_launcher_force_kills_detached_stale_clients() -> None:
+    launcher_text = LAUNCH_BEAGLE_STREAM_CLIENT.read_text(encoding="utf-8")
+
+    assert "stop_stale_beagle_stream_processes()" in launcher_text
+    assert "pkill -TERM -u" in launcher_text
+    assert "pkill -KILL -u" in launcher_text
+    assert 'action=killed reason=term-timeout' in launcher_text
+    assert launcher_text.count("stop_stale_beagle_stream_processes") >= 3
+
+
 def test_prepare_host_downloads_rebuilds_payload_after_public_mirror_fallback() -> None:
     prepare_text = PREPARE_HOST_DOWNLOADS.read_text(encoding="utf-8")
 
@@ -519,7 +529,7 @@ def test_usbip_autobind_keeps_usb_audio_local_for_mic_bridge() -> None:
     assert 'printf \'%s\\n\' "/usr/sbin/usbip"' in (ROOT / "thin-client-assistant" / "runtime" / "beagle_usb_runtime_env.sh").read_text(encoding="utf-8")
     assert 'printf \'%s\\n\' "/usr/sbin/usbipd"' in actions_text
     assert 'beagle_audio_input_bridge.py' in actions_text
-    assert '$(usb_attach_host):$(audio_input_remote_port):127.0.0.1:$(audio_input_local_port)' in actions_text
+    assert '${tunnel_attach_host}:${tunnel_audio_port}:127.0.0.1:$(audio_input_local_port)' in actions_text
     assert 'PVE_THIN_CLIENT_BEAGLE_USB_EXTRA_REVERSE_FORWARDS' in actions_text
     assert 'append_extra_reverse_forwards "$tunnel_attach_host" reverse_forwards' in actions_text
     assert "ignoring invalid extra reverse forward" in actions_text
@@ -531,6 +541,9 @@ def test_usbip_autobind_keeps_usb_audio_local_for_mic_bridge() -> None:
     assert '"$ssh_cmd" -N \\' in actions_text
     assert 'exec "$ssh_cmd" -N \\' not in actions_text
     assert 'PVE_THIN_CLIENT_BEAGLE_AUDIO_INPUT_PORT:-43200' in actions_text
+    assert 'tunnel_audio_port="$(audio_input_remote_port)"' in actions_text
+    assert '${tunnel_attach_host}:${tunnel_audio_port}:127.0.0.1:$(audio_input_local_port)' in actions_text
+    assert '${tunnel_audio_port}:127.0.0.1:${tunnel_audio_port}' not in actions_text
     assert '"PVE_THIN_CLIENT_BEAGLE_USB_EXTRA_REVERSE_FORWARDS", config.get("usb_extra_reverse_forwards", "")' in apply_enrollment_text
     assert '"PVE_THIN_CLIENT_BEAGLE_AUDIO_INPUT_PORT", config.get("usb_audio_input_port", "")' in apply_enrollment_text
     assert 'PVE_THIN_CLIENT_BEAGLE_AUDIO_INPUT_PORT="$BEAGLE_AUDIO_INPUT_PORT"' in write_config_text
@@ -543,6 +556,9 @@ def test_usbip_autobind_keeps_usb_audio_local_for_mic_bridge() -> None:
     assert '--channels={channels}' in bridge_text
     assert '--frame-msec", type=int' in bridge_text
     assert 'PVE_THIN_CLIENT_BEAGLE_AUDIO_INPUT_FRAME_MSEC", "20"' in bridge_text
+    assert 'apply_runtime_usb_config' in apply_enrollment_text
+    assert '--runtime-usb' in apply_enrollment_text
+    assert 'device.sync.usb-config' in DEVICE_SYNC.read_text(encoding="utf-8")
 
 
 def test_beaglestream_client_production_baseline_matches_live_smooth_profile() -> None:

--- a/thin-client-assistant/live-build/config/includes.chroot/usr/local/bin/pve-thin-client-audio-init
+++ b/thin-client-assistant/live-build/config/includes.chroot/usr/local/bin/pve-thin-client-audio-init
@@ -24,7 +24,7 @@ start_background_process() {
 
   log_dir="$(ensure_audio_log_dir)"
   log_file="$log_dir/$log_name"
-  nohup "$@" >>"$log_file" 2>&1 </dev/null &
+  nohup "$@" 8>&- 9>&- >>"$log_file" 2>&1 </dev/null &
 }
 
 start_wireplumber_session() {
@@ -42,7 +42,7 @@ start_wireplumber_session() {
 
   nohup dbus-run-session -- sh -lc \
     "export HOME='$runtime_home'; export XDG_RUNTIME_DIR='$runtime_dir'; export DISPLAY='$display'; exec wireplumber" \
-    >>"$log_file" 2>&1 </dev/null &
+    8>&- 9>&- >>"$log_file" 2>&1 </dev/null &
 }
 
 pulse_health_ready() {
@@ -96,9 +96,9 @@ ensure_audio_stack() {
 
   if command -v flock >/dev/null 2>&1; then
     {
-      flock -w "$lock_wait" 9 || return 0
+      flock -w "$lock_wait" 8 || return 0
       _ensure_audio_stack_unlocked
-    } 9>"$lock_file"
+    } 8>"$lock_file"
     return 0
   fi
 
@@ -161,9 +161,9 @@ alsa_pcm_candidates() {
 }
 
 select_default_pcm() {
-  local row score card dev
+  local _score card dev
 
-  while read -r score card dev; do
+  while read -r _score card dev; do
     [[ -n "${card:-}" && -n "${dev:-}" ]] || continue
     printf '%s,%s\n' "$card" "$dev"
     return 0
@@ -450,7 +450,7 @@ watch_mode() {
     done
   fi
 
-  for i in $(seq 1 "$loops"); do
+  for ((i = 1; i <= loops; i++)); do
     configure_alsa
     ensure_audio_stack
     configure_pulse

--- a/thin-client-assistant/runtime/apply_enrollment_config.py
+++ b/thin-client-assistant/runtime/apply_enrollment_config.py
@@ -52,6 +52,59 @@ def _remove_file_if_exists(path: Path) -> None:
         return
 
 
+def apply_runtime_usb_config(response_path: Path, config_path: Path) -> bool:
+    """Refresh USB tunnel material without rotating endpoint credentials."""
+    payload = json.loads(response_path.read_text(encoding="utf-8"))
+    config = payload.get("runtime_config", {}) if isinstance(payload, dict) else {}
+    if not isinstance(config, dict) or not config:
+        return False
+
+    existing = _load_env_file(config_path)
+    updated = dict(existing)
+    values = (
+        ("PVE_THIN_CLIENT_BEAGLE_USB_ENABLED", "usb_enabled", "1" if config.get("usb_enabled", True) else "0"),
+        ("PVE_THIN_CLIENT_BEAGLE_USB_TUNNEL_HOST", "usb_tunnel_host", config.get("usb_tunnel_host", "")),
+        ("PVE_THIN_CLIENT_BEAGLE_USB_TUNNEL_USER", "usb_tunnel_user", config.get("usb_tunnel_user", "beagle")),
+        ("PVE_THIN_CLIENT_BEAGLE_USB_TUNNEL_PORT", "usb_tunnel_port", config.get("usb_tunnel_port", "")),
+        ("PVE_THIN_CLIENT_BEAGLE_CAMERA_STREAM_PORT", "usb_camera_stream_port", config.get("usb_camera_stream_port", "")),
+        ("PVE_THIN_CLIENT_BEAGLE_AUDIO_INPUT_PORT", "usb_audio_input_port", config.get("usb_audio_input_port", "")),
+        ("PVE_THIN_CLIENT_BEAGLE_USB_EXTRA_REVERSE_FORWARDS", "usb_extra_reverse_forwards", config.get("usb_extra_reverse_forwards", "")),
+        ("PVE_THIN_CLIENT_BEAGLE_USB_ATTACH_HOST", "usb_tunnel_attach_host", config.get("usb_tunnel_attach_host", "")),
+    )
+    for env_key, config_key, value in values:
+        if config_key in config:
+            updated[env_key] = _json_env(value)
+
+    key_path = config_path.parent / "usb-tunnel.key"
+    known_hosts_path = config_path.parent / "usb-tunnel-known_hosts"
+    updated["PVE_THIN_CLIENT_BEAGLE_USB_TUNNEL_PRIVATE_KEY_FILE"] = _json_env(key_path)
+    updated["PVE_THIN_CLIENT_BEAGLE_USB_TUNNEL_KNOWN_HOSTS_FILE"] = _json_env(known_hosts_path)
+
+    changed = updated != existing
+    if changed:
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        _write_env_file(config_path, updated)
+
+    usb_key = str(config.get("usb_tunnel_private_key", "") or "")
+    if usb_key and (not key_path.exists() or key_path.read_text(encoding="utf-8") != usb_key):
+        key_path.write_text(usb_key, encoding="utf-8")
+        changed = True
+    if usb_key:
+        key_path.chmod(0o600)
+
+    usb_known_host = str(config.get("usb_tunnel_known_host", "") or "")
+    known_hosts_content = usb_known_host.rstrip() + "\n" if usb_known_host else ""
+    if known_hosts_content and (
+        not known_hosts_path.exists() or known_hosts_path.read_text(encoding="utf-8") != known_hosts_content
+    ):
+        known_hosts_path.write_text(known_hosts_content, encoding="utf-8")
+        changed = True
+    if known_hosts_content:
+        known_hosts_path.chmod(0o644)
+
+    return changed
+
+
 def apply_enrollment_config(
     response_path: Path,
     config_path: Path,
@@ -156,9 +209,14 @@ def apply_enrollment_config(
 
 def main(argv: list[str] | None = None) -> int:
     args = list(sys.argv[1:] if argv is None else argv)
+    if len(args) == 3 and args[0] == "--runtime-usb":
+        changed = apply_runtime_usb_config(Path(args[1]), Path(args[2]))
+        print("changed" if changed else "unchanged")
+        return 0
     if len(args) not in {3, 4}:
         raise SystemExit(
-            "usage: apply_enrollment_config.py <response_json> <thinclient_conf> <credentials_env> [enrollment_conf]"
+            "usage: apply_enrollment_config.py <response_json> <thinclient_conf> <credentials_env> [enrollment_conf]\n"
+            "       apply_enrollment_config.py --runtime-usb <response_json> <thinclient_conf>"
         )
     enrollment_conf = Path(args[3]) if len(args) == 4 else None
     apply_enrollment_config(Path(args[0]), Path(args[1]), Path(args[2]), enrollment_conf)

--- a/thin-client-assistant/runtime/beagle_usb_runtime_actions.sh
+++ b/thin-client-assistant/runtime/beagle_usb_runtime_actions.sh
@@ -176,7 +176,7 @@ usb_status_json() {
 
 run_usb_tunnel_daemon() {
   local ssh_cmd camera_pid=""
-  local tunnel_user tunnel_host tunnel_attach_host tunnel_port
+  local tunnel_user tunnel_host tunnel_attach_host tunnel_port tunnel_audio_port=""
   local rc
   local ssh_output=""
   local -a reverse_forwards=()
@@ -195,7 +195,8 @@ run_usb_tunnel_daemon() {
   start_audio_input_bridge || true
   reverse_forwards+=("-R" "${tunnel_attach_host}:${tunnel_port}:127.0.0.1:3240")
   if audio_input_bridge_enabled; then
-    reverse_forwards+=("-R" "$(usb_attach_host):$(audio_input_remote_port):127.0.0.1:$(audio_input_local_port)")
+    tunnel_audio_port="$(audio_input_remote_port)"
+    reverse_forwards+=("-R" "${tunnel_attach_host}:${tunnel_audio_port}:127.0.0.1:$(audio_input_local_port)")
   fi
   append_extra_reverse_forwards "$tunnel_attach_host" reverse_forwards
 
@@ -227,8 +228,10 @@ run_usb_tunnel_daemon() {
     local -a _audio_pids=()
     pgrep_cmd="$(pgrep_bin)"
     mapfile -t stale_tunnel_pids < <("$pgrep_cmd" -f "ssh .*${tunnel_user}@${tunnel_host}.*-R ${tunnel_attach_host}:${tunnel_port}:127.0.0.1:3240" 2>/dev/null || true)
-    mapfile -t _audio_pids < <("$pgrep_cmd" -f "ssh .*${tunnel_user}@${tunnel_host}.*-R ${tunnel_attach_host}:${tunnel_audio_port}:127.0.0.1:${tunnel_audio_port}" 2>/dev/null || true)
-    stale_tunnel_pids+=("${_audio_pids[@]}")
+    if [[ -n "$tunnel_audio_port" ]]; then
+      mapfile -t _audio_pids < <("$pgrep_cmd" -f "ssh .*${tunnel_user}@${tunnel_host}.*-R ${tunnel_attach_host}:${tunnel_audio_port}:127.0.0.1:$(audio_input_local_port)" 2>/dev/null || true)
+      stale_tunnel_pids+=("${_audio_pids[@]}")
+    fi
     if [[ "${#stale_tunnel_pids[@]}" -eq 0 ]]; then
       return 0
     fi

--- a/thin-client-assistant/runtime/device_sync.sh
+++ b/thin-client-assistant/runtime/device_sync.sh
@@ -6,6 +6,7 @@ if [[ "$SCRIPT_DIR" == /var/local/* ]]; then
 fi
 COMMON_SH="${COMMON_SH:-$SCRIPT_DIR/common.sh}"
 RUNTIME_ENDPOINT_ENROLLMENT_SH="${RUNTIME_ENDPOINT_ENROLLMENT_SH:-$SCRIPT_DIR/runtime_endpoint_enrollment.sh}"
+APPLY_ENROLLMENT_CONFIG_PY="${APPLY_ENROLLMENT_CONFIG_PY:-$SCRIPT_DIR/apply_enrollment_config.py}"
 
 if [[ -r "$COMMON_SH" ]]; then
   # shellcheck disable=SC1090
@@ -696,6 +697,19 @@ if commands.get("install_sys_update") or system.get("install_requested"):
 else:
   system_marker.unlink(missing_ok=True)
 PY
+  local usb_config_result=""
+  if [[ -r "$APPLY_ENROLLMENT_CONFIG_PY" ]]; then
+    usb_config_result="$(python3 "$APPLY_ENROLLMENT_CONFIG_PY" --runtime-usb "$response_file" "$(runtime_thinclient_config_file)" 2>/dev/null || true)"
+  fi
+  if [[ "$usb_config_result" == "changed" ]]; then
+    load_runtime_config >/dev/null 2>&1 || true
+    if [[ "${PVE_THIN_CLIENT_BEAGLE_USB_ENABLED:-0}" == "1" ]]; then
+      systemctl restart --no-block beagle-usb-tunnel.service >/dev/null 2>&1 || true
+    else
+      systemctl stop --no-block beagle-usb-tunnel.service >/dev/null 2>&1 || true
+    fi
+    beagle_log_event "device.sync.usb-config" "status=changed tunnel_service=${PVE_THIN_CLIENT_BEAGLE_USB_ENABLED:-0}"
+  fi
   if [[ -f "$restart_marker" ]]; then
   rm -f "$restart_marker" >/dev/null 2>&1 || true
   if pgrep -x beagle-stream >/dev/null 2>&1 || pgrep -x beagle-stream-client >/dev/null 2>&1; then

--- a/thin-client-assistant/runtime/launch-beagle-stream-client.sh
+++ b/thin-client-assistant/runtime/launch-beagle-stream-client.sh
@@ -717,14 +717,25 @@ ensure_beagle_stream_wireguard_ready() {
 }
 
 stop_stale_beagle_stream_processes() {
-  if ! command -v pkill >/dev/null 2>&1; then
+  local wait_round
+  if ! command -v pgrep >/dev/null 2>&1 || ! command -v pkill >/dev/null 2>&1; then
     return 0
   fi
   # A stale process from a previous failed run can reconnect before the launcher
   # reaches pairing checks. Kill only stream-mode client processes for this uid.
-  if pkill -u "$(id -u)" -f '^/opt/beagle-stream-client/usr/bin/beagle-stream stream ' >/dev/null 2>&1; then
-    beagle_log_event "beagle-stream-client.stale-process" "action=terminated"
+  if ! pgrep -u "$(id -u)" -f '^/opt/beagle-stream-client/usr/bin/beagle-stream stream ' >/dev/null 2>&1; then
+    return 0
   fi
+  pkill -TERM -u "$(id -u)" -f '^/opt/beagle-stream-client/usr/bin/beagle-stream stream ' >/dev/null 2>&1 || true
+  for wait_round in {1..10}; do
+    if ! pgrep -u "$(id -u)" -f '^/opt/beagle-stream-client/usr/bin/beagle-stream stream ' >/dev/null 2>&1; then
+      beagle_log_event "beagle-stream-client.stale-process" "action=terminated wait_round=${wait_round}"
+      return 0
+    fi
+    sleep 0.2
+  done
+  pkill -KILL -u "$(id -u)" -f '^/opt/beagle-stream-client/usr/bin/beagle-stream stream ' >/dev/null 2>&1 || true
+  beagle_log_event "beagle-stream-client.stale-process" "action=killed reason=term-timeout"
 }
 
 wait_for_beagle_stream_client_manager_registration() {
@@ -799,7 +810,7 @@ main() {
   stop_stale_beagle_stream_processes
 
   beagle_stream_startup_status_start
-  trap 'beagle_stream_startup_status_stop' EXIT
+  trap 'beagle_stream_startup_status_stop; stop_stale_beagle_stream_processes' EXIT
   beagle_stream_startup_status_step "1" "Runtime initialisieren" "Launcher und Runtime-Konfiguration laden"
 
   have_binary "$bin" || {
@@ -1176,6 +1187,9 @@ main() {
     else
       stream_exit=$?
     fi
+    # The client may detach from the wrapper or ignore TERM. Ensure a retry can
+    # never leave an older video/audio session running beside the next one.
+    stop_stale_beagle_stream_processes
 
     stream_unpaired_detected=0
     if tail -n +"$((stream_start_line + 1))" "$BEAGLE_STREAM_CLIENT_STREAM_LOG" 2>/dev/null | grep -Eqi 'has not been paired|not been paired|please open moonlight to pair|unauthorized|not paired'; then

--- a/thin-client-assistant/runtime/launch-beagle-stream-client.sh
+++ b/thin-client-assistant/runtime/launch-beagle-stream-client.sh
@@ -915,6 +915,7 @@ main() {
   fi
 
   if [[ "$hostless_beagle_stream" != "1" ]]; then
+    beagle_stream_startup_status_step "4" "Stream-Ziel pruefen" "VM-Adresse und Stream-API erreichen"
     wait_for_stream_target || {
       beagle_log_event "beagle-stream-client.unreachable" "host=${host} connect_host=${connect_host:-$host} port=${port:-default}"
       echo "Beagle Stream Client host '$host' is unreachable from this network." >&2
@@ -1151,6 +1152,14 @@ main() {
       fi
       if tail -n +"$((stream_start_line + 1))" "$BEAGLE_STREAM_CLIENT_STREAM_LOG" 2>/dev/null | grep -Eqi 'Server certificate mismatch|"applist" request failed|Failed to find application|Failed to load application|has not been paired|not been paired|please open moonlight to pair|unauthorized|not paired'; then
         beagle_log_event "beagle-stream-client.repair-trigger" "attempt=${stream_attempt}/${max_attempts} pid=${stream_pid} reason=applist-or-pairing"
+        kill -TERM "$stream_pid" >/dev/null 2>&1 || true
+        sleep 1
+        kill -KILL "$stream_pid" >/dev/null 2>&1 || true
+        stream_forced_restart=1
+        break
+      fi
+      if tail -n +"$((stream_start_line + 1))" "$BEAGLE_STREAM_CLIENT_STREAM_LOG" 2>/dev/null | grep -Eqi 'Failed to initialize video capture/encoding|Host returned error:.*Error 503'; then
+        beagle_log_event "beagle-stream-client.repair-trigger" "attempt=${stream_attempt}/${max_attempts} pid=${stream_pid} reason=server-capture-unavailable"
         kill -TERM "$stream_pid" >/dev/null 2>&1 || true
         sleep 1
         kill -KILL "$stream_pid" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary

- repair VM100 DHCP/X11/audio recovery and prevent detached BeagleStream clients from surviving launcher retries
- refresh VM-scoped USB tunnel configuration during device sync, including legacy installer identities
- fix microphone reverse-forward cleanup and rate-limit disconnected VM bridge logs
- tolerate and atomically repair malformed fleet telemetry JSONL shards
- install SMART monitoring through both server installation paths and update operational state

## Live validation

- thinclient `192.168.178.30`: exactly one 1920x1080 desktop stream, stereo playback, USB tunnel active, no failed units or new error logs
- physical SC420 USB microphone: automatically selected, unmuted at 100%, and transported to VM100
- VM100 active recording: 983040 bytes, non-zero signal, 496 frames received, `dropped=0`, `reconnects=0`
- `srv1`: recurring device sync HTTP 200, repaired telemetry shard with zero invalid lines, all reverse listeners active, RAID1 `[UU]`, smartd active
- full local tests: `2005 passed` unit, `91 passed` integration
- Python and shell syntax, `git diff --check`, and repository secret hygiene passed

## Operational risks

- `beagle-os.com` still serves an expired external TLS certificate; the available operator key cannot access that webhost and no TLS bypass was added
- `srv1` has historical SATA NCQ timeouts and high-hour disks; controlled cable/controller inspection and sequential RAID member replacement are recorded as P0 operations
- a fresh thinclient image boot without runtime deployment remains an explicit gate