### PR TITLE
Prevent microphone bridge idle backpressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed thin-client stream retries so detached BeagleStream clients are terminated and reaped before relaunch, preventing duplicate video/audio sessions after recovery.
 - Added VM-scoped USB tunnel configuration refresh through device sync, including legacy installer-token support, corrected microphone reverse-forward cleanup, and rate-limited VM microphone reconnect logs.
+- Prevented idle microphone consumers from backpressuring the thinclient audio bridge until `parec` exhausts its internal buffer by connecting only while the VM PipeWire source is actively consumed.
 - Hardened fleet telemetry JSONL ingestion against malformed records and concurrent pruning, and added SMART monitoring packages to host installer paths.
 - Fixed thin-client USB preset propagation so `PVE_THIN_CLIENT_PRESET_BEAGLE_MANAGER_TOKEN` survives installer generation and local preset installs instead of being dropped, preventing fresh USB recreates from losing required manager auth context.
 - Added stable/rolling Beagle update channels: server repo auto-update can now follow stable release tags or rolling GitHub main, and the Update Center exposes the channel switch beside installed/remote versions.

--- a/projectleader/state.md
+++ b/projectleader/state.md
@@ -232,6 +232,11 @@ LastHope/Diamond gates moving forward.
 - VM100 exposes `beagle_tc_microphone` as its default PipeWire source. An active
   recording smoke test captured 983040 bytes with non-zero input signal and
   transferred 496 frames with zero drops and zero reconnects.
+- The VM microphone receiver now opens its TCP stream only while PipeWire marks
+  `beagle_tc_microphone` as `RUNNING`. A forced idle/active transition removed
+  the idle connection and `parec` process, then reconnected automatically with
+  zero drops. This prevents unconsumed PCM from growing to PulseAudio's 96 MB
+  allocation limit during long idle periods.
 - A malformed telemetry JSONL record caused device sync HTTP 500 responses.
   Telemetry reads now skip malformed records, ingestion is serialized, and
   pruning replaces shards atomically. The live shard was repaired and repeated

--- a/scripts/lib/beagle-tc-mic-bridge
+++ b/scripts/lib/beagle-tc-mic-bridge
@@ -68,9 +68,16 @@ normalize_source() {
   pactl set-source-volume "$SOURCE_NAME" 100% >/dev/null 2>&1 || true
 }
 
+source_is_running() {
+  pactl list short sources 2>/dev/null \
+    | awk -v source="$SOURCE_NAME" '$2 == source && $NF == "RUNNING" {found=1} END {exit !found}'
+}
+
 stream_once() {
   python3 - "$BRIDGE_HOST" "$BRIDGE_PORT" "$FIFO_PATH" "$RATE" "$CHANNELS" "$FRAME_MSEC" "$PREBUFFER_MSEC" "$MAX_BUFFER_MSEC" "$STATS_INTERVAL_SEC" <<'PY'
+import errno
 import math
+import os
 import socket
 import sys
 import time
@@ -117,25 +124,34 @@ def emit_stats(prefix: str, fill_frames: int) -> None:
     f"silence={stats['silence_inserted']} dropped={stats['frames_dropped']} reconnects={stats['reconnects']}"
   )
 
-try:
-  sock = socket.create_connection((host, port), timeout=10)
-except OSError:
-  raise SystemExit(75) from None
-
-with sock:
+while True:
   try:
-    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+    fifo_fd = os.open(fifo, os.O_WRONLY | os.O_NONBLOCK)
+    break
+  except OSError as exc:
+    if exc.errno != errno.ENXIO:
+      raise
+    time.sleep(0.1)
+
+with os.fdopen(fifo_fd, "wb", buffering=0) as handle:
+  try:
+    sock = socket.create_connection((host, port), timeout=10)
   except OSError:
-    pass
-  sock.settimeout(0.05)
-  net_buffer = bytearray()
-  frame_buffer: deque[bytes] = deque()
-  started = False
-  remote_closed = False
-  next_write_deadline = time.monotonic()
-  next_stats = time.monotonic() + stats_interval_sec
-  with open(fifo, "wb", buffering=0) as handle:
+    raise SystemExit(75) from None
+
+  with sock:
+    try:
+      sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+      sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+    except OSError:
+      pass
+    sock.settimeout(0.05)
+    net_buffer = bytearray()
+    frame_buffer: deque[bytes] = deque()
+    started = False
+    remote_closed = False
+    next_write_deadline = time.monotonic()
+    next_stats = time.monotonic() + stats_interval_sec
     while True:
       now = time.monotonic()
 
@@ -173,7 +189,16 @@ with sock:
           stats["underruns"] += 1
           stats["silence_inserted"] += 1
 
-        handle.write(frame)
+        try:
+          written = handle.write(frame)
+        except (BlockingIOError, BrokenPipeError):
+          remote_closed = True
+          frame_buffer.clear()
+          break
+        if written != len(frame):
+          remote_closed = True
+          frame_buffer.clear()
+          break
         stats["frames_tx"] += 1
         next_write_deadline += frame_sec
         now = time.monotonic()
@@ -201,6 +226,10 @@ log "ready host=$BRIDGE_HOST port=$BRIDGE_PORT source=$SOURCE_NAME fifo=$FIFO_PA
 
 failures=0
 while true; do
+  if ! source_is_running; then
+    sleep "$RECONNECT_DELAY"
+    continue
+  fi
   if stream_once; then
     failures=0
     log "stream ended; reconnecting"

--- a/tests/unit/test_tc_mic_bridge_jitter_regressions.py
+++ b/tests/unit/test_tc_mic_bridge_jitter_regressions.py
@@ -53,3 +53,16 @@ def test_tc_mic_bridge_rate_limits_unavailable_stream_logs() -> None:
     assert 'raise SystemExit(75) from None' in script
     assert 'failures=$((failures + 1))' in script
     assert '$((failures % RETRY_LOG_EVERY))' in script
+
+
+def test_tc_mic_bridge_connects_only_while_source_is_consumed() -> None:
+    script = (ROOT / "scripts" / "lib" / "beagle-tc-mic-bridge").read_text(encoding="utf-8")
+
+    fifo_open = 'os.open(fifo, os.O_WRONLY | os.O_NONBLOCK)'
+    assert fifo_open in script
+    assert script.index(fifo_open) < script.index("socket.create_connection")
+    assert "except (BlockingIOError, BrokenPipeError):" in script
+    assert "frame_buffer.clear()" in script
+    assert "source_is_running()" in script
+    assert '$NF == "RUNNING"' in script
+    assert "if ! source_is_running; then" in script


### PR DESCRIPTION
## Summary

- start the VM microphone TCP stream only while `beagle_tc_microphone` is actively consumed
- open the FIFO nonblocking before connecting to the thinclient and close cleanly on pipe backpressure
- prevent long idle periods from growing `parec` buffers to PulseAudio's 96 MB allocation limit

## Validation

- focused regression suite: `6 passed`
- shell syntax and `git diff --check` passed
- live forced idle: source became `SUSPENDED`, no TCP connection and no thinclient `parec` process
- live forced active: automatic reconnect to SC420, zero drops and zero reconnects
- VM100 and thinclient microphone services remained active